### PR TITLE
fix: RDI lpLinkError should be Bool

### DIFF
--- a/src/main/scala/interfaces/Rdi.scala
+++ b/src/main/scala/interfaces/Rdi.scala
@@ -50,7 +50,7 @@ class Rdi(rdiParams: RdiParams) extends Bundle {
     * internal error conditions with lp_linkerror received from Protocol Layer
     * on FDI.
     */
-  val lpLinkError = Output(PhyStateReq())
+  val lpLinkError = Output(Bool())
 
   /** Physical Layer to Adapter Status indication of the Interface.
     *


### PR DESCRIPTION
§8.1 Table 8.1 Sheet 1 `lp_linkerror` (revision 1.1, version 1.0 page 288)