### PR TITLE
Enum for Rdi sb width

### DIFF
--- a/src/main/scala/interfaces/Rdi.scala
+++ b/src/main/scala/interfaces/Rdi.scala
@@ -4,7 +4,7 @@ package interfaces
 import chisel3._
 import chisel3.util._
 
-case class RdiParams(width: Int, sbWidth: Int)
+case class RdiParams(width: Int, sbWidth: RdiSbWidth.Value)
 
 /** The raw D2D interface (RDI), from the perspective of the D2D Adapter. */
 class Rdi(rdiParams: RdiParams) extends Bundle {
@@ -80,8 +80,9 @@ class Rdi(rdiParams: RdiParams) extends Bundle {
   val lpWakeReq = Output(Bool())
   val plWakeAck = Input(Bool())
 
-  val plConfig = Flipped(Valid(UInt(rdiParams.sbWidth.W)))
+  val sbWidth = rdiParams.sbWidth.id
+  val plConfig = Flipped(Valid(UInt(sbWidth.W)))
   val plConfigCredit = Input(Bool())
-  val lpConfig = Valid(UInt(rdiParams.sbWidth.W))
+  val lpConfig = Valid(UInt(sbWidth.W))
   val lpConfigCredit = Output(Bool())
 }

--- a/src/main/scala/interfaces/Types.scala
+++ b/src/main/scala/interfaces/Types.scala
@@ -96,3 +96,9 @@ object FlitFormat extends ChiselEnum {
   val latencyOpt256NoOptional = Value(0x5.U(4.W))
   val latencyOpt256Optional = Value(0x6.U(4.W))
 }
+
+object RdiSbWidth extends Enumeration {
+  val width8 = Value(8)
+  val width16 = Value(16)
+  val width32 = Value(32)
+}


### PR DESCRIPTION
Added an enum for sideband width. To prevent other values from being passed as parameters, I used "Value" for the enum. Only change to code is that sbwidth needs a ".id" appendix to get the integer value. I created another val in Rdi.scala for convenience.