### PR TITLE
Add Verilog-AMS behavioral model for 8GHz Bang-Bang PLL

### DIFF
--- a/verilog/bbpll.vams
+++ b/verilog/bbpll.vams
@@ -1,0 +1,196 @@
+// ============================================================================
+// Bang-Bang Phase-Locked Loop (BBPLL) - Top-Level Verilog-A Model
+// ============================================================================
+//
+// ============================================================================
+// WARNING: TRANSIENT NOISE MUST BE ENABLED FOR PLL TO LOCK!
+// ============================================================================
+//
+// This BBPLL model requires transient noise to be enabled in Spectre for 
+// proper locking behavior. Without noise, the bang-bang phase detector may
+// not provide sufficient dithering for the loop to converge.
+//
+// To enable transient noise in Spectre:
+//   1. In ADE: Simulation → Options → Analog → Set "noisefmax" parameter
+//      Example: noisefmax=64G
+//   2. In netlist: Add "noisefmax=64G" to the transient analysis statement
+//      Example: tran tran stop=100u noisefmax=64G
+//   3. Command line: spectre +aps netlist.scs +noisefmax=64G
+//
+// Recommended noisefmax: At least 64GHz (above the DCO frequency)
+//
+// ============================================================================
+//
+// Description:
+//   A complete digital PLL system using bang-bang phase detection. The PLL
+//   locks an 8GHz DCO to a 100MHz reference crystal oscillator using a
+//   digital loop filter with delta-sigma modulation for fractional control.
+//
+// Architecture:
+//   - Reference Crystal: 100MHz clock with white phase noise floor
+//   - DCO: 8GHz digitally-controlled oscillator with phase noise modeling
+//   - Main Divider: ÷80 frequency divider for feedback path
+//   - BBPD: Bang-bang phase detector comparing reference and feedback
+//   - Digital Loop Filter: PI controller (Kp + Ki/(1-z^-1))
+//   - DSM: 1st-order delta-sigma modulator to reduce quantization noise
+//   - DSM Clock Divider: ÷8 divider providing 1GHz clock for DSM
+//
+// Loop Parameters:
+//   - Loop Bandwidth: 10MHz
+//   - Phase Margin: 60°
+//   - Kp = 0.5126, Ki = 0.0563 (pre-computed for desired response)
+//
+// Ports:
+//   reset       - Input, active high reset signal
+//   clk_out     - Output, 8GHz DCO output clock
+//   Dctrl_value - Output, digital control value to DCO (for monitoring)
+//
+// Parameters:
+//   vdd                  - Supply voltage (default: 0.75V)
+//   ref_clk_freq         - Reference clock frequency (default: 100MHz)
+//   ref_PN_floor_dBcHz   - Reference phase noise floor (default: -160 dBc/Hz)
+//   dco_PN_WN_100MHz     - DCO white noise at 100MHz offset (default: -130 dBc/Hz)
+//   dco_PN_FN_10kHz      - DCO flicker noise at 10kHz offset (default: -15 dBc/Hz)
+//   Kp, Ki               - Loop filter proportional and integral gains
+//   Dctrl_setpoint       - DCO control setpoint for lock (default: 128)
+//
+// ============================================================================
+
+`include "constants.vams"
+`include "disciplines.vams"
+
+module bbpll(reset, clk_out, Dctrl_value);
+
+output clk_out; electrical clk_out; 
+output Dctrl_value; electrical Dctrl_value;
+input reset; electrical reset;
+
+// General parameters
+parameter real vdd = 0.75;
+parameter real ref_clk_freq = 100M;
+parameter real ref_PN_floor_dBcHz = -160;
+parameter real dco_PN_WN_100MHz = -130;    // White noise: -130 dBc/Hz at 100MHz offset
+parameter real dco_PN_FN_10kHz = -15;      // Flicker noise: -15 dBc/Hz at 10kHz offset;
+// Kp and Ki are pre-computed to achieve 10MHz BW and 60 PM
+parameter real Kp = 0.5126;
+parameter real Ki = 0.0563;
+parameter real Dctrl_setpoint = 128;
+parameter real dctrl_reset_value = 128;
+
+// ========== Reference Crystal Oscillator ==========
+electrical clk_ref;
+
+model_ref_crystal #(
+    .steps_per_cycle(100),
+    .vdd(vdd),
+    .osc_freq(ref_clk_freq),
+    .white_noise_floor_dBcHz(ref_PN_floor_dBcHz)
+) ref_crystal_inst(
+    .clk_ref(clk_ref)
+);
+
+// ========== Digitally Controlled Oscillator (DCO) ==========
+electrical Dctrl;
+electrical Vctrl_setpoint;
+electrical dummy_net1;
+
+model_DVCO #(
+    .clk_middle_freq(8G),
+    .Kvco(0),                    // VCO gain doesn't matter since only DCO is used
+    .Kdco(1.25M),
+    .vdd(vdd),
+    .PN_WN_100MHz(dco_PN_WN_100MHz),
+    .PN_FN_10kHz(dco_PN_FN_10kHz),
+    .steps_per_cycle(100),
+    .Dctrl_setpoint(Dctrl_setpoint),
+    .Vctrl_setpoint(0)
+) vco_inst(
+    .Vctrl(Vctrl_setpoint),
+    .Dctrl(Dctrl),
+    .clk_out(clk_out),
+    .phase_noise_out(dummy_net1)
+);
+
+// ========== Main Frequency Divider (80) ==========
+electrical clk_fb;
+
+model_freq_divider #(
+    .division_factor(80),           // Divide by 80
+    .t_rise(5p),
+    .t_delay(50p),
+    .vdd(vdd)
+) freq_div_inst(
+    .clk_highspeed(clk_out),
+    .clk_divided(clk_fb)
+);
+
+// ========== Bang-Bang Phase Detector (BBPD) ==========
+electrical early;
+electrical late;
+
+model_BBPD #(
+    .vdd(vdd),
+    .t_rise(5p),
+    .t_delay(5p)
+) bbpd_inst(
+    .clk_ref(clk_ref),
+    .clk_fb(clk_fb),
+    .early(early),
+    .late(late)
+);
+
+// ========== Digital Loop Filter ==========
+electrical Dinteger;
+electrical Dfrac;
+
+model_digital_loop_filter #(
+    .digital_latency(500p),
+    .trise(5p),
+    .vdd(vdd),
+    .dlf_bitwidth(8),
+    .dctrl_reset_value(dctrl_reset_value),
+    .rise_p1_fall_m1(1),
+    .Kp(Kp),
+    .Ki(Ki)
+) dlf_inst(
+    .clk(clk_ref),
+    .reset(reset),
+    .early(early),
+    .late(late),
+    .Dinteger(Dinteger),
+    .Dfrac(Dfrac),
+    .Dctrl(Dctrl_value)
+);
+
+// ========== DSM Clock Divider (8) ==========
+electrical clk_dsm;
+
+model_freq_divider #(
+    .division_factor(8),            // Divide by 8 to get 1GHz from 8GHz clk_out
+    .t_rise(5p),
+    .t_delay(50p),
+    .vdd(vdd)
+) dsm_freq_div_inst(
+    .clk_highspeed(clk_out),
+    .clk_divided(clk_dsm)
+);
+
+// ========== Delta-Sigma Modulator ==========
+electrical Dfrac_DSM;
+
+model_1storder_DSmodulator #(
+    .vdd(vdd),
+    .t_rise(50p)
+) dsm_inst(
+    .Din_frac(Dfrac),
+    .clk(clk_dsm),
+    .Dout(Dfrac_DSM)
+);
+
+// ========== Control Signal Summation ==========
+analog begin
+    V(Vctrl_setpoint) <+ 0;
+    V(Dctrl) <+ V(Dinteger) + V(Dfrac_DSM);
+end
+
+endmodule

--- a/verilog/bbpll_subcircuits/model_1storder_DSmodulator.vams
+++ b/verilog/bbpll_subcircuits/model_1storder_DSmodulator.vams
@@ -1,0 +1,35 @@
+// A simple delta-sigma modulator model in Verilog-A.
+// Input is digital fractional value in [0, 1), output is a 1-bit digital stream.
+
+`include "constants.vams"
+`include "disciplines.vams"
+
+module model_1storder_DSmodulator(Din_frac, clk, Dout);
+
+input Din_frac; electrical Din_frac;  // Input fractional value in [0, 1)
+input clk;      electrical clk;
+output Dout;    electrical Dout;      // Output 1-bit digital stream
+
+parameter real vdd = 0.75;
+parameter real t_rise = 50p;
+
+real accumulator;
+integer Dout_value;
+
+analog begin
+    // Update accumulator on clock rising edge
+    @(cross(V(clk) - vdd/2, 1)) begin
+        accumulator = accumulator + V(Din_frac) - (V(Dout) > vdd/2 ? 1 : 0);
+        
+        if (accumulator >= 0.5) begin
+            Dout_value = 1;
+        end else begin
+            Dout_value = 0;
+        end
+    end
+
+    // Output with transition filtering
+    V(Dout) <+ transition(Dout_value * vdd, 0, t_rise);
+end
+
+endmodule

--- a/verilog/bbpll_subcircuits/model_BBPD.vams
+++ b/verilog/bbpll_subcircuits/model_BBPD.vams
@@ -11,7 +11,7 @@ module model_BBPD(clk_ref, clk_fb, early, late);
     output early, late;
 	electrical early, late;
 
-    parameter real vdd = 0.85;
+    parameter real vdd = 0.75;
     parameter real t_rise = 5p;
     parameter real t_delay = 5p;
 

--- a/verilog/bbpll_subcircuits/model_BBPD.vams
+++ b/verilog/bbpll_subcircuits/model_BBPD.vams
@@ -1,0 +1,46 @@
+// BBPD is implemented using arbiter style.
+// Whichever arrives first will trigger the output, and the output is reset when both inputs are low.
+
+`include "constants.vams"
+`include "disciplines.vams"
+
+module model_BBPD(clk_ref, clk_fb, early, late);
+
+    input clk_ref, clk_fb;
+	electrical clk_ref, clk_fb;
+    output early, late;
+	electrical early, late;
+
+    parameter real vdd = 0.85;
+    parameter real t_rise = 5p;
+    parameter real t_delay = 5p;
+
+    integer early_value, late_value;
+    integer compared;
+
+    analog begin
+        if (V(clk_ref) < vdd / 2 && V(clk_fb) < vdd / 2) begin
+            compared = 0;
+        end
+
+        @(cross(V(clk_ref) - vdd/2, 1)) begin
+            if (compared == 0) begin
+                late_value = 1;
+                early_value = 0;
+                compared = 1;
+            end
+        end
+        @(cross(V(clk_fb) - vdd/2, 1)) begin
+            if (compared == 0) begin
+                early_value = 1;
+                late_value = 0;
+                compared = 1;
+            end
+        end
+
+        V(early) <+ transition(early_value*vdd, t_delay, t_rise);
+        V(late) <+ transition(late_value*vdd, t_delay, t_rise);
+
+    end
+
+endmodule

--- a/verilog/bbpll_subcircuits/model_DVCO.vams
+++ b/verilog/bbpll_subcircuits/model_DVCO.vams
@@ -1,0 +1,56 @@
+// Verilog-A model of a digitally-voltage controlled oscillator with integrator-like phase noise.
+
+`include "constants.vams"
+`include "disciplines.vams"
+
+`define DCTRL_BITWIDTH 8
+
+module model_DVCO(Vctrl, Dctrl, clk_out, phase_noise_out);
+
+input Vctrl; electrical Vctrl;
+input Dctrl; electrical Dctrl;
+output clk_out; electrical clk_out;
+output phase_noise_out; electrical phase_noise_out;
+
+parameter real clk_middle_freq = 8G;      // middle frequency of the VCO
+parameter real Kvco = 32M;               // VCO gain in Hz/V
+parameter real Kdco = 1.25M;                 // DCO gain in Hz/LSB
+parameter real vdd = 0.75;
+parameter real PN_WN_100MHz = -130;       // white noise floor at 100MHz offset in dBc/Hz
+parameter real PN_FN_10kHz = -15;         // flicker noise at 10kHz offset in dBc/Hz
+parameter integer steps_per_cycle = 100;
+parameter real Dctrl_setpoint = 128;
+
+real Vctrl_setpoint = vdd/2;
+
+real WN_PSD, FN_PSD;
+real osc_modulated_freq;
+real real_noise_integ;
+real phase;
+integer sign;
+
+analog begin
+    // Calculate instantaneous frequency from control inputs
+    osc_modulated_freq = Kvco * (V(Vctrl) - Vctrl_setpoint) + Kdco * (V(Dctrl) - Dctrl_setpoint);
+    
+    // Calculate phase noise PSD
+    WN_PSD = (2*`M_PI)**2 * (100M)**2 * (10**(PN_WN_100MHz/10));
+    FN_PSD = (2*`M_PI)**2 * (10k)**3 * (10**(PN_FN_10kHz/10));
+    real_noise_integ = white_noise(WN_PSD) + flicker_noise(FN_PSD, 1);
+    
+    // Accumulate phase with noise modulation
+    phase = 2*`M_PI*clk_middle_freq*$abstime + idtmod(2*`M_PI*osc_modulated_freq, 0, 2*`M_PI) + idt(real_noise_integ);
+    
+    // Output phase noise for monitoring
+    V(phase_noise_out) <+ real_noise_integ;
+    
+    // Bound simulation timestep
+    $bound_step(1.0 / clk_middle_freq / steps_per_cycle);
+    
+    // Event-driven square wave output with smooth transitions
+    @(cross(cos(phase), 0)) sign = cos(phase) > 0 ? 1 : 0;
+    V(clk_out) <+ transition(sign * vdd, 5p, 5p);
+end
+
+
+endmodule

--- a/verilog/bbpll_subcircuits/model_digital_loop_filter.vams
+++ b/verilog/bbpll_subcircuits/model_digital_loop_filter.vams
@@ -15,7 +15,7 @@ output Dctrl;    electrical Dctrl;
 
 parameter real digital_latency = 500p;
 parameter real trise = 50p;
-parameter real vdd = 0.85;
+parameter real vdd = 0.75;
 parameter real dlf_bitwidth = 8;
 parameter real dctrl_reset_value = 128;
 parameter integer rise_p1_fall_m1 = 1;

--- a/verilog/bbpll_subcircuits/model_digital_loop_filter.vams
+++ b/verilog/bbpll_subcircuits/model_digital_loop_filter.vams
@@ -1,0 +1,56 @@
+// Verilog-A model for a digital loop filter: Kp + Ki/(1-z^-1) used in a digital PLL
+
+`include "constants.vams"
+`include "disciplines.vams"
+
+module model_digital_loop_filter(clk, reset, early, late, Dinteger, Dfrac, Dctrl);
+
+input clk;       electrical clk;
+input reset;     electrical reset;     // active high reset
+input early;     electrical early;     // unused, kept for interface compatibility
+input late;      electrical late;
+output Dinteger; electrical Dinteger;
+output Dfrac;    electrical Dfrac;
+output Dctrl;    electrical Dctrl;
+
+parameter real digital_latency = 500p;
+parameter real trise = 50p;
+parameter real vdd = 0.85;
+parameter real dlf_bitwidth = 8;
+parameter real dctrl_reset_value = 128;
+parameter integer rise_p1_fall_m1 = 1;
+parameter real Kp = 1;
+parameter real Ki = 1;
+
+real integrator_state = dctrl_reset_value / Ki;
+real late_p1_early_m1;
+real Dctrl_value;
+
+analog begin
+    // Phase detector output: +1 if late, -1 if early
+    if (V(late) > vdd/2)
+        late_p1_early_m1 = 1;
+    else
+        late_p1_early_m1 = -1;
+
+    // Update integrator on clock edge
+    @(cross(V(clk) - vdd/2, rise_p1_fall_m1)) begin
+        if (V(reset) > vdd/2) begin
+            integrator_state = dctrl_reset_value / Ki;
+        end else begin
+            // Anti-overflow protection
+            if (integrator_state * Ki + late_p1_early_m1 * Kp < 2**dlf_bitwidth - 1 &&
+                integrator_state * Ki + late_p1_early_m1 * Kp > 0) begin
+                integrator_state = integrator_state + late_p1_early_m1;
+            end
+        end
+    end
+    
+    // Calculate PI controller output with flooring for integer part
+    Dctrl_value = Ki * integrator_state + Kp * late_p1_early_m1;
+    V(Dinteger) <+ transition($floor(Dctrl_value), digital_latency, trise);
+    V(Dfrac) <+ transition(Dctrl_value - $floor(Dctrl_value), digital_latency, trise);
+    V(Dctrl) <+ transition(Dctrl_value, digital_latency, trise);
+end
+
+endmodule

--- a/verilog/bbpll_subcircuits/model_freq_divider.vams
+++ b/verilog/bbpll_subcircuits/model_freq_divider.vams
@@ -1,0 +1,30 @@
+// A simple Verilog-A model for a simple frequency divider.
+// The divider can only perform division of even integers.
+
+`include "constants.vams"
+`include "disciplines.vams"
+
+module model_freq_divider(clk_highspeed, clk_divided);
+
+input clk_highspeed; electrical clk_highspeed;
+output clk_divided;  electrical clk_divided;
+
+parameter integer division_factor = 16;
+parameter real t_rise = 5p;
+parameter real t_delay = 50p;
+parameter real vdd = 0.75;
+
+integer count;
+integer sign;
+
+analog begin
+    // Increment counter on rising edge of high-speed clock
+    @(cross(V(clk_highspeed) - vdd/2, 1))
+        count = (count + 1) % division_factor;
+    
+    // Generate divided clock: high for first half of division period
+    sign = count < (division_factor / 2) ? 1 : 0;
+    V(clk_divided) <+ transition(sign * vdd, t_delay, t_rise);
+end
+
+endmodule

--- a/verilog/bbpll_subcircuits/model_ref_crystal.vams
+++ b/verilog/bbpll_subcircuits/model_ref_crystal.vams
@@ -1,0 +1,37 @@
+// Verilog-A model of a reference crystal oscillator with phase noise.
+// Only a white phase noise floor is modeled here.
+
+`include "constants.vams"
+`include "disciplines.vams"
+
+module model_ref_crystal(clk_ref);
+
+output clk_ref; electrical clk_ref;
+
+parameter integer steps_per_cycle = 100;
+parameter real vdd = 0.75;
+parameter real osc_freq = 100M; // nominal frequency in Hz
+parameter real white_noise_floor_dBcHz = -160;
+
+real white_noise_floor_linear;
+real white_noise_td;
+real white_noise_filtered;
+real phase;
+
+analog begin
+    // Calculate white noise floor in linear scale
+    white_noise_floor_linear = 10**(white_noise_floor_dBcHz/10);
+    white_noise_td = white_noise(white_noise_floor_linear);
+    // filter the white noise at Nyquist frequency to prevent folding
+    white_noise_filtered = laplace_nd(white_noise_td, {1.0}, {1.0, 1.0/(`M_PI*osc_freq)});
+    
+    // Use linear phase accumulation instead of idtmod to avoid LTE convergence issues
+    // This is valid since the reference crystal frequency is constant
+    phase = 2 * `M_PI * osc_freq * $abstime + white_noise_filtered;
+    
+    $bound_step(1.0 / osc_freq / steps_per_cycle);
+    V(clk_ref) <+ vdd/2 + vdd/2 * sin(phase);
+end
+
+
+endmodule


### PR DESCRIPTION
Implements a complete BBPLL system with the following specifications:

**System Overview:**
- 8GHz DCO locked to 100MHz reference crystal
- 10MHz loop bandwidth, 60° phase margin
- Digital PI controller with 1st-order ΔΣ modulator

**Components:**
- `bbpll.vams` - Top-level PLL integration
- `bbpll_subcircuits/` - Modular subcircuits (BBPD, DVCO, loop filter, ΔΣM, dividers, crystal)

**Usage Note:**
Requires transient noise enabled in Spectre (`noisefmax ≥ 64GHz`) for proper locking.

**Testing:**
- [x] Behavioral simulation validates PLL lock
- [x] Phase noise performance meets specifications
<img width="971" height="571" alt="image" src="https://github.com/user-attachments/assets/7e3d8fb0-2392-4494-af71-97be4899675f" />

