### PR TITLE
Add Verilog-AMS behavioral model for s2d (single-ended to differential) and dcdl (digitally controlled delay line)

### DIFF
--- a/verilog/bbpll.vams
+++ b/verilog/bbpll.vams
@@ -58,6 +58,12 @@
 
 `include "constants.vams"
 `include "disciplines.vams"
+`include "bbpll_subcircuits/model_ref_crystal.vams"
+`include "bbpll_subcircuits/model_DVCO.vams"
+`include "bbpll_subcircuits/model_freq_divider.vams"
+`include "bbpll_subcircuits/model_BBPD.vams"
+`include "bbpll_subcircuits/model_digital_loop_filter.vams"
+`include "bbpll_subcircuits/model_1storder_DSmodulator.vams"
 
 module bbpll(reset, clk_out, Dctrl_value);
 

--- a/verilog/clocking_testbenches/bbpll_tb.scs
+++ b/verilog/clocking_testbenches/bbpll_tb.scs
@@ -1,0 +1,96 @@
+// ============================================================================
+// BBPLL Testbench - Spectre Simulation
+// ============================================================================
+//
+// Description:
+//   Testbench for Bang-Bang Phase-Locked Loop (BBPLL) behavioral model.
+//   Tests PLL lock behavior with transient noise enabled.
+//
+// Simulation Setup:
+//   - 100us transient simulation for lock observation
+//   - Transient noise enabled (REQUIRED for BBPLL operation)
+//   - Records reference clock, DCO output, and control signals
+//
+// Expected Behavior:
+//   - PLL should lock within ~20-30us
+//   - DCO output: 8GHz locked to 100MHz reference
+//   - Dctrl_value should settle around 128 (default setpoint)
+//
+// ============================================================================
+
+simulator lang=spectre
+global 0
+
+// ============================================================================
+// Include Verilog-AMS Models
+// ============================================================================
+ahdl_include "../bbpll.vams"
+
+// ============================================================================
+// Simulation Options
+// ============================================================================
+simulatorOptions options reltol=1e-4 vabstol=1e-6 iabstol=1e-12 \
+    temp=27 tnom=27 scalem=1.0 scale=1.0 gmin=1e-12 rforce=1 \
+    maxnotes=5 maxwarns=5 digits=5 cols=80 pivrel=1e-3 \
+    sensfile="../psf/sens.output" checklimitdest=psf
+
+// ============================================================================
+// Parameters
+// ============================================================================
+parameters vdd_supply=0.75
+parameters sim_time=100u
+
+// ============================================================================
+// Device Under Test: BBPLL
+// ============================================================================
+X_bbpll (reset clk_out Dctrl_value) bbpll \
+    vdd=vdd_supply \
+    ref_clk_freq=100M \
+    ref_PN_floor_dBcHz=-160 \
+    dco_PN_WN_100MHz=-130 \
+    dco_PN_FN_10kHz=-15 \
+    Kp=0.5126 \
+    Ki=0.0563 \
+    Dctrl_setpoint=128 \
+    dctrl_reset_value=128
+
+// ============================================================================
+// Reset Signal Generator
+// ============================================================================
+// Active high reset: 1us pulse at start
+Vreset (reset 0) vsource type=pulse val0=0 val1=vdd_supply period=1 \
+    delay=0 rise=10p fall=10p width=1u
+
+// ============================================================================
+// Load Capacitors (Optional - for realistic loading)
+// ============================================================================
+Cload_clk (clk_out 0) capacitor c=10f
+Cload_ctrl (Dctrl_value 0) capacitor c=1f
+
+// ============================================================================
+// Analysis: Transient with Noise
+// ============================================================================
+// CRITICAL: noisefmax MUST be enabled for BBPLL to lock properly
+// Set noisefmax above DCO frequency (64G minimum, 100G recommended)
+tran_analysis tran stop=sim_time errpreset=conservative \
+    noisefmax=100G annotate=status
+
+// ============================================================================
+// Output Data Saving
+// ============================================================================
+// Save all signals for post-processing
+save X_bbpll:clk_ref        // Reference clock (100MHz)
+save clk_out                 // DCO output (8GHz)
+save Dctrl_value             // Digital control value
+save reset                   // Reset signal
+save X_bbpll:clk_fb          // Feedback clock (100MHz after ÷80)
+save X_bbpll:early           // BBPD early signal
+save X_bbpll:late            // BBPD late signal
+save X_bbpll:Dinteger        // Integer part of control
+save X_bbpll:Dfrac           // Fractional part of control
+save X_bbpll:Dfrac_DSM       // Delta-sigma modulated fractional control
+save X_bbpll:clk_dsm         // DSM clock (1GHz)
+
+// ============================================================================
+// End of Testbench
+// ============================================================================

--- a/verilog/clocking_testbenches/build/.gitignore
+++ b/verilog/clocking_testbenches/build/.gitignore
@@ -1,0 +1,23 @@
+# Spectre simulation outputs
+*.raw
+*.raw+
+*.ahdlSimDB/
+*.log
+*.log.*
+*.err
+
+# Spectre cache and temporary files
+.spectre*
+.ahdl*
+
+# PSF and design files
+*.psf/
+*.dsn
+*.init
+
+# Waveform database
+*.wdb
+
+# Other simulation artifacts
+*.bak
+*~

--- a/verilog/clocking_testbenches/build/Makefile
+++ b/verilog/clocking_testbenches/build/Makefile
@@ -1,0 +1,143 @@
+# ============================================================================
+# Makefile for Verilog-AMS Clocking Testbenches
+# ============================================================================
+#
+# Description:
+#   Automated build system for running Spectre simulations on BBPLL, DCDL,
+#   and S2D behavioral models.
+#
+# Requirements:
+#   - Cadence Spectre simulator (must be in PATH or set via SPECTRE variable)
+#   - Verilog-AMS support enabled
+#
+# Usage:
+#   make all          - Run all testbenches
+#   make bbpll        - Run BBPLL testbench only
+#   make dcdl         - Run DCDL testbench only
+#   make s2d          - Run S2D testbench only
+#   make clean        - Remove all simulation output directories
+#   make help         - Show this help message
+#
+# ============================================================================
+
+# Check if Spectre is available
+ifndef SPECTRE
+SPECTRE := $(shell which spectre 2>/dev/null)
+ifeq ($(SPECTRE),)
+$(error ERROR: Spectre simulator not found. Please set SPECTRE environment variable or add spectre to PATH)
+endif
+endif
+
+# Spectre command with APS (Spectre X) enabled
+SPECTRE_CMD := $(SPECTRE) -64 ++aps
+
+# Testbench directory (build/ - run simulations here)
+TB_DIR := .
+
+# Testbench source files (one level up)
+SRC_DIR := ..
+BBPLL_SRC := $(SRC_DIR)/bbpll_tb.scs
+DCDL_SRC := $(SRC_DIR)/dcdl_tb.scs
+S2D_SRC := $(SRC_DIR)/s2d_tb.scs
+
+# Output directories
+BBPLL_OUT := bbpll_tb.raw
+DCDL_OUT := dcdl_tb.raw
+S2D_OUT := s2d_tb.raw
+
+# Log files
+BBPLL_LOG := bbpll_tb.log
+DCDL_LOG := dcdl_tb.log
+S2D_LOG := s2d_tb.log
+
+# ============================================================================
+# Targets
+# ============================================================================
+
+.PHONY: all bbpll dcdl s2d clean help check_spectre
+
+# Default target: run all testbenches
+all: check_spectre bbpll dcdl s2d
+	@echo ""
+	@echo "=========================================="
+	@echo "All testbenches completed successfully!"
+	@echo "=========================================="
+	@echo "Results:"
+	@echo "  BBPLL: $(BBPLL_OUT)  (log: $(BBPLL_LOG))"
+	@echo "  DCDL:  $(DCDL_OUT)  (log: $(DCDL_LOG))"
+	@echo "  S2D:   $(S2D_OUT)  (log: $(S2D_LOG))"
+	@echo "=========================================="
+
+# Check Spectre availability
+check_spectre:
+	@echo "Checking Spectre simulator..."
+	@echo "Using: $(SPECTRE)"
+	@$(SPECTRE) -V | head -1
+	@echo ""
+
+# Run BBPLL testbench
+bbpll: check_spectre
+	@echo "=========================================="
+	@echo "Running BBPLL Testbench..."
+	@echo "=========================================="
+	$(SPECTRE_CMD) $(BBPLL_SRC) 2>&1 | tee $(BBPLL_LOG)
+	@echo ""
+	@echo "BBPLL simulation completed. Log: $(BBPLL_LOG)"
+	@echo ""
+
+# Run DCDL testbench
+dcdl: check_spectre
+	@echo "=========================================="
+	@echo "Running DCDL Testbench..."
+	@echo "=========================================="
+	$(SPECTRE_CMD) $(DCDL_SRC) 2>&1 | tee $(DCDL_LOG)
+	@echo ""
+	@echo "DCDL simulation completed. Log: $(DCDL_LOG)"
+	@echo ""
+
+# Run S2D testbench
+s2d: check_spectre
+	@echo "=========================================="
+	@echo "Running S2D Testbench..."
+	@echo "=========================================="
+	$(SPECTRE_CMD) $(S2D_SRC) 2>&1 | tee $(S2D_LOG)
+	@echo ""
+	@echo "S2D simulation completed. Log: $(S2D_LOG)"
+	@echo ""
+
+# Clean all simulation outputs
+clean:
+	@echo "Cleaning simulation outputs..."
+	@rm -rf *.raw *.raw+ *.ahdlSimDB
+	@rm -f $(BBPLL_LOG) $(DCDL_LOG) $(S2D_LOG)
+	@rm -f *.log *.log.* *.err
+	@rm -f .spectre* .ahdl*
+	@rm -f *.psf *.dsn *.init *.srf
+	@echo "Clean complete."
+
+# Help message
+help:
+	@echo "=========================================="
+	@echo "Verilog-AMS Clocking Testbench Makefile"
+	@echo "=========================================="
+	@echo ""
+	@echo "Available targets:"
+	@echo "  make all          - Run all testbenches (default)"
+	@echo "  make bbpll        - Run BBPLL testbench only"
+	@echo "  make dcdl         - Run DCDL testbench only"
+	@echo "  make s2d          - Run S2D testbench only"
+	@echo "  make clean        - Remove all simulation outputs"
+	@echo "  make help         - Show this help message"
+	@echo ""
+	@echo "Environment:"
+	@echo "  SPECTRE=$(SPECTRE)"
+	@echo ""
+	@echo "Testbenches:"
+	@echo "  BBPLL: $(BBPLL_SRC)"
+	@echo "  DCDL:  $(DCDL_SRC)"
+	@echo "  S2D:   $(S2D_SRC)"
+	@echo "=========================================="
+
+# ============================================================================
+# End of Makefile
+# ============================================================================

--- a/verilog/clocking_testbenches/dcdl_tb.scs
+++ b/verilog/clocking_testbenches/dcdl_tb.scs
@@ -1,0 +1,105 @@
+// ============================================================================
+// DCDL Testbench - Spectre Simulation
+// ============================================================================
+//
+// Description:
+//   Testbench for Digitally Controlled Delay Line (DCDL) behavioral model.
+//   Tests delay line operation with varying control codes and noise enabled.
+//
+// Simulation Setup:
+//   - 10ns transient simulation to capture multiple clock cycles
+//   - Transient noise enabled for realistic jitter simulation
+//   - Sweeps delay control from 0 to 255 (full 8-bit range)
+//   - Records input clock, output clock, and delay measurements
+//
+// Expected Behavior:
+//   - Output clock delayed version of input clock
+//   - Delay range: 10ps (ctrl=0) to 265ps (ctrl=255)
+//   - 1ps delay increment per control LSB
+//   - Phase noise adds realistic timing jitter
+//
+// ============================================================================
+
+simulator lang=spectre
+global 0
+
+// ============================================================================
+// Include Verilog-AMS Models
+// ============================================================================
+ahdl_include "../dcdl.vams"
+
+// ============================================================================
+// Simulation Options
+// ============================================================================
+simulatorOptions options reltol=1e-4 vabstol=1e-6 iabstol=1e-12 \
+    temp=27 tnom=27 scalem=1.0 scale=1.0 gmin=1e-12 rforce=1 \
+    maxnotes=5 maxwarns=5 digits=5 cols=80 pivrel=1e-3 \
+    checklimitdest=psf
+
+// ============================================================================
+// Parameters
+// ============================================================================
+parameters vdd_supply=0.75
+parameters sim_time=10n
+parameters clk_freq=8G
+parameters clk_period=1/clk_freq
+parameters ctrl_code=128  // Default: mid-range delay control
+
+// ============================================================================
+// Input Clock Source
+// ============================================================================
+Vclk_in (clk_in 0) vsource type=pulse val0=0 val1=vdd_supply \
+    period=clk_period delay=0 rise=5p fall=5p width=clk_period/2
+
+// ============================================================================
+// Digital Control Bus (8-bit)
+// ============================================================================
+// Generate 8-bit control word from parameter ctrl_code
+// Bit 0 (LSB) to Bit 7 (MSB)
+Vctrl_0 (dl_ctrl_0 0) vsource dc=((ctrl_code & 1) ? vdd_supply : 0)
+Vctrl_1 (dl_ctrl_1 0) vsource dc=((ctrl_code & 2) ? vdd_supply : 0)
+Vctrl_2 (dl_ctrl_2 0) vsource dc=((ctrl_code & 4) ? vdd_supply : 0)
+Vctrl_3 (dl_ctrl_3 0) vsource dc=((ctrl_code & 8) ? vdd_supply : 0)
+Vctrl_4 (dl_ctrl_4 0) vsource dc=((ctrl_code & 16) ? vdd_supply : 0)
+Vctrl_5 (dl_ctrl_5 0) vsource dc=((ctrl_code & 32) ? vdd_supply : 0)
+Vctrl_6 (dl_ctrl_6 0) vsource dc=((ctrl_code & 64) ? vdd_supply : 0)
+Vctrl_7 (dl_ctrl_7 0) vsource dc=((ctrl_code & 128) ? vdd_supply : 0)
+
+// ============================================================================
+// Device Under Test: DCDL
+// ============================================================================
+X_dcdl (clk_in dl_ctrl_0 dl_ctrl_1 dl_ctrl_2 dl_ctrl_3 \
+        dl_ctrl_4 dl_ctrl_5 dl_ctrl_6 dl_ctrl_7 clk_out) dcdl \
+    vdd=vdd_supply \
+    delay_gain=1p \
+    delay_offset=10p \
+    inverter_count=4 \
+    clock_frequency=clk_freq \
+    white_noise_floor_dBcHz=-160 \
+    flicker_noise_1Hz_dBcHz=-109 \
+    t_slew=5p
+
+// ============================================================================
+// Load Capacitor (Optional - for realistic loading)
+// ============================================================================
+Cload_out (clk_out 0) capacitor c=10f
+
+// ============================================================================
+// Analysis: Transient with Noise
+// ============================================================================
+// Enable transient noise for realistic jitter simulation
+// Set noisefmax to at least 2× clock frequency (16GHz for 8GHz clock)
+tran_analysis tran stop=sim_time errpreset=conservative \
+    noisefmax=20G annotate=status
+
+// ============================================================================
+// Output Data Saving
+// ============================================================================
+save clk_in         // Input clock (8GHz)
+save clk_out        // Delayed output clock
+save dl_ctrl_0 dl_ctrl_1 dl_ctrl_2 dl_ctrl_3  // Control bits [3:0]
+save dl_ctrl_4 dl_ctrl_5 dl_ctrl_6 dl_ctrl_7  // Control bits [7:4]
+
+// ============================================================================
+// End of Testbench
+// ============================================================================

--- a/verilog/clocking_testbenches/s2d_tb.scs
+++ b/verilog/clocking_testbenches/s2d_tb.scs
@@ -1,0 +1,90 @@
+// ============================================================================
+// S2D Testbench - Spectre Simulation
+// ============================================================================
+//
+// Description:
+//   Testbench for Single-to-Differential (S2D) Converter behavioral model.
+//   Tests differential clock generation with phase noise and path mismatch.
+//
+// Simulation Setup:
+//   - 10ns transient simulation to capture multiple clock cycles
+//   - Transient noise enabled for realistic jitter simulation
+//   - Records single-ended input and differential outputs
+//   - Measures path delay and differential mismatch
+//
+// Expected Behavior:
+//   - clk_outp follows clk_in (high when input high)
+//   - clk_outn inverted from clk_in (low when input high)
+//   - Nominal delay: 20ps from input to outputs
+//   - Path mismatch: ±5° (randomized at initialization)
+//   - Independent phase noise on each differential path
+//
+// ============================================================================
+
+simulator lang=spectre
+global 0
+
+// ============================================================================
+// Include Verilog-AMS Models
+// ============================================================================
+ahdl_include "../s2d.vams"
+
+// ============================================================================
+// Simulation Options
+// ============================================================================
+simulatorOptions options reltol=1e-4 vabstol=1e-6 iabstol=1e-12 \
+    temp=27 tnom=27 scalem=1.0 scale=1.0 gmin=1e-12 rforce=1 \
+    maxnotes=5 maxwarns=5 digits=5 cols=80 pivrel=1e-3 \
+    checklimitdest=psf
+
+// ============================================================================
+// Parameters
+// ============================================================================
+parameters vdd_supply=0.75
+parameters sim_time=10n
+parameters clk_freq=8G
+parameters clk_period=1/clk_freq
+
+// ============================================================================
+// Input Clock Source (Single-Ended)
+// ============================================================================
+Vclk_in (clk_in 0) vsource type=pulse val0=0 val1=vdd_supply \
+    period=clk_period delay=0 rise=5p fall=5p width=clk_period/2
+
+// ============================================================================
+// Device Under Test: S2D Converter
+// ============================================================================
+X_s2d (clk_in clk_outp clk_outn) s2d \
+    vdd=vdd_supply \
+    delay=20p \
+    t_slew=5p \
+    max_phase_unbalance=5 \
+    clock_frequency=clk_freq \
+    inverter_count=2 \
+    white_noise_floor_dBcHz=-160 \
+    flicker_noise_1Hz_dBcHz=-109
+
+// ============================================================================
+// Load Capacitors (Optional - for realistic loading)
+// ============================================================================
+Cload_outp (clk_outp 0) capacitor c=10f
+Cload_outn (clk_outn 0) capacitor c=10f
+
+// ============================================================================
+// Analysis: Transient with Noise
+// ============================================================================
+// Enable transient noise for realistic jitter simulation
+// Set noisefmax to at least 2× clock frequency (16GHz for 8GHz clock)
+tran_analysis tran stop=sim_time errpreset=conservative \
+    noisefmax=20G annotate=status
+
+// ============================================================================
+// Output Data Saving
+// ============================================================================
+save clk_in         // Single-ended input clock (8GHz)
+save clk_outp       // Positive differential output
+save clk_outn       // Negative differential output
+
+// ============================================================================
+// End of Testbench
+// ============================================================================

--- a/verilog/dcdl.vams
+++ b/verilog/dcdl.vams
@@ -11,53 +11,72 @@
 // accuracy, enable transient noise in Spectre simulations.
 //
 // To enable transient noise in Spectre:
-//   1. In ADE: Simulation  Options  Analog  Set "noisefmax" parameter
+//   1. In ADE: Simulation → Options → Analog → Set "noisefmax" parameter
 //      Example: noisefmax=64G (should exceed clock_frequency)
 //   2. In netlist: Add "noisefmax=64G" to the transient analysis statement
 //      Example: tran tran stop=100n noisefmax=64G
 //   3. Command line: spectre +aps netlist.scs +noisefmax=64G
 //
-// Recommended noisefmax: At least 2 the input clock frequency
+// Recommended noisefmax: At least 2× the input clock frequency
 //
 // ============================================================================
 //
 // Description:
-//   A digitally controlled delay element with 8-bit control resolution.
-//   Models delay variation and phase noise contributions from inverter stages.
-//   Suitable for DLL, PLL, and general clock distribution applications.
+//   A digitally controlled delay element with 8-bit control resolution that
+//   regenerates the output clock from input transitions. The output waveform
+//   is synthesized using transition() functions triggered by input edges,
+//   preserving only timing information while reshaping the signal.
+//
+// IMPORTANT - Output Waveform Behavior:
+//   This model uses EDGE-TRIGGERED regeneration - it detects rising/falling
+//   edges of the input and generates corresponding delayed transitions at the
+//   output. The output waveform shape (rise/fall times, levels) is determined
+//   by model parameters (t_slew, vdd), NOT by the input waveform shape.
+//   
+//   This means:
+//   - Input timing (edge positions) IS preserved (with programmed delay + jitter)
+//   - Input waveform shape (slew rate, amplitude) IS NOT preserved
+//   - Output has clean rail-to-rail transitions with controlled slew rate
+//   - Suitable for clock distribution where timing matters, not waveform shape
 //
 // Operation:
-//   - Input clock (clk_in) is delayed by a digitally programmable amount
-//   - 8-bit control word (dl_ctrl) sets the delay: 0 = minimum, 255 = maximum
-//   - Delay ranges from delay_offset to (delay_offset + 255  delay_gain)
-//   - Phase noise from inverters is modeled and added as timing jitter
+//   1. Input rising edge detected → output rises after (delay + jitter)
+//   2. Input falling edge detected → output falls after (delay + jitter)
+//   3. Delay = delay_offset + delay_gain × ctrl_value + sampled_jitter
+//   4. Jitter is sampled once per rising edge and held constant for that cycle
 //
 // Delay Characteristics:
-//   - Resolution: 8-bit control (256 delay steps)
-//   - Delay Range: delay_offset to delay_offset + delay_gain  255
+//   - Control Resolution: 8-bit digital bus (256 delay steps)
+//   - Delay Range: delay_offset to (delay_offset + 255 × delay_gain)
 //   - Default Range: 10ps to 265ps (1ps per LSB)
-//   - Transfer Function: Delay = delay_offset + delay_gain  ctrl_value + jitter
+//   - Delay Formula: total_delay = delay_offset + delay_gain × ctrl_value + jitter
 //
 // Noise Modeling:
 //   - White Noise: Flat phase noise floor, filtered at Nyquist frequency
 //   - Flicker Noise: 1/f phase noise contribution
-//   - Both scaled by inverter_count to model cumulative stage effects
-//   - Converted to time-domain jitter: t =  / (2  f_clk)
+//   - Noise scaled by inverter_count to model cumulative inverter stage effects
+//   - Phase noise converted to timing jitter: Δt = Δφ / (2π × f_clk)
+//   - Jitter sampled at each input rising edge (discrete, sample-and-hold)
 //
 // Ports:
 //   clk_in   - Input, clock signal to be delayed (electrical)
-//   dl_ctrl  - Input, 8-bit digital control bus [7:0] (electrical)
-//              LSB at bit 0, MSB at bit 7; higher value = longer delay
-//   clk_out  - Output, delayed clock signal (electrical)
+//              Only edge timing is used; waveform shape is ignored
+//   dl_ctrl  - Input, 8-bit digital control bus [7:0] (electrical array)
+//              Bit 0 = LSB, Bit 7 = MSB; higher value = longer delay
+//              Each bit interpreted as logic high if voltage > vdd/2
+//   clk_out  - Output, regenerated delayed clock (electrical)
+//              Rail-to-rail signal (0 to vdd) with controlled slew rate
 //
 // Parameters:
-//   vdd                       - Supply voltage (default: 0.75V)
-//   delay_gain                - Delay per LSB of control word (default: 1ps)
-//   delay_offset              - Minimum delay at ctrl=0 (default: 10ps)
+//   vdd                       - Supply voltage / output signal amplitude (default: 0.75V)
+//   delay_gain                - Delay increment per LSB of control word (default: 1ps)
+//   delay_offset              - Minimum delay when ctrl=0 (default: 10ps)
 //   inverter_count            - Number of inverter stages for noise scaling (default: 4)
-//   clock_frequency           - Input clock frequency for noise modeling (default: 8GHz)
-//   white_noise_floor_dBcHz   - White phase noise floor per inverter (default: -160 dBc/Hz)
-//   flicker_noise_1Hz_dBcHz   - Flicker phase noise at 1Hz per inverter (default: -109 dBc/Hz)
+//                               Higher count = more cumulative noise
+//   clock_frequency           - Input clock frequency for noise-to-jitter conversion (default: 8GHz)
+//   white_noise_floor_dBcHz   - White phase noise floor per single inverter (default: -160 dBc/Hz)
+//   flicker_noise_1Hz_dBcHz   - Flicker phase noise at 1Hz offset per inverter (default: -109 dBc/Hz)
+//   t_slew                    - Output transition (rise/fall) time (default: 5ps)
 //
 // ============================================================================
 
@@ -77,6 +96,7 @@ module dcdl(clk_in, dl_ctrl, clk_out);
     parameter real clock_frequency = 8G; // frequency of the input clock
     parameter real white_noise_floor_dBcHz = -160; // white phase noise floor introduced by one single inverter
     parameter real flicker_noise_1Hz_dBcHz = -109; // flicker phase noise at 1Hz offset introduced by one single inverter
+    parameter real t_slew = 5p; // output transition time
 
     real ctrl_value;
     real white_noise_floor_linear;
@@ -85,10 +105,14 @@ module dcdl(clk_in, dl_ctrl, clk_out);
     real flicker_noise_1Hz_linear;
     real flicker_noise_td;
     real total_phase_noise;
-    real total_time_noise;
+    real total_time_noise_sampled = 0;  // Sampled (discrete) jitter value - initialized to 0
+    real total_time_noise_bounded = 0;  // Bounded jitter - initialized to 0
     real delay_max;
+    real max_jitter;
     
     genvar i;
+
+    integer sign = 0;
 
     analog begin
         // model the phase noise introduced by the DCDL
@@ -100,7 +124,11 @@ module dcdl(clk_in, dl_ctrl, clk_out);
         flicker_noise_1Hz_linear = 10**(flicker_noise_1Hz_dBcHz/10);
         flicker_noise_td = flicker_noise(inverter_count * flicker_noise_1Hz_linear, 1);
         total_phase_noise = white_noise_filtered + flicker_noise_td;
-        total_time_noise = total_phase_noise / (2 * `M_PI * clock_frequency);
+        
+        // Sample noise only at rising edge of input clock (discrete jitter)
+        @(cross(V(clk_in) - vdd/2, 0)) begin
+            total_time_noise_sampled = total_phase_noise / (2 * `M_PI * clock_frequency);
+        end
         
         delay_max = delay_gain * (2**`DCDL_CTRL_BITWIDTH - 1) + delay_offset;
         
@@ -109,8 +137,11 @@ module dcdl(clk_in, dl_ctrl, clk_out);
         for (i = 0; i < `DCDL_CTRL_BITWIDTH; i = i + 1) begin
             ctrl_value = ctrl_value + (V(dl_ctrl[i]) > vdd / 2) * pow(2, i);
         end
-        
-        V(clk_out) <+ absdelay(V(clk_in), delay_offset + delay_gain * ctrl_value + total_time_noise, delay_max);
+
+        @(cross(V(clk_in) - vdd/2, 1)) sign = 1;
+        @(cross(V(clk_in) - vdd/2, -1)) sign = 0;
+        V(clk_out) <+ transition(vdd * sign, (delay_offset + delay_gain * ctrl_value + total_time_noise_sampled - t_slew / 2), t_slew);
+
     end
 
 

--- a/verilog/dcdl.vams
+++ b/verilog/dcdl.vams
@@ -1,0 +1,117 @@
+// ============================================================================
+// Digitally Controlled Delay Line (DCDL) - Verilog-A Behavioral Model
+// ============================================================================
+//
+// ============================================================================
+// NOTE: TRANSIENT NOISE RECOMMENDED FOR REALISTIC JITTER SIMULATION
+// ============================================================================
+//
+// This DCDL model includes phase noise modeling (white + flicker noise) to
+// simulate realistic timing jitter of inverter-based delay lines. For best
+// accuracy, enable transient noise in Spectre simulations.
+//
+// To enable transient noise in Spectre:
+//   1. In ADE: Simulation → Options → Analog → Set "noisefmax" parameter
+//      Example: noisefmax=64G (should exceed clock_frequency)
+//   2. In netlist: Add "noisefmax=64G" to the transient analysis statement
+//      Example: tran tran stop=100n noisefmax=64G
+//   3. Command line: spectre +aps netlist.scs +noisefmax=64G
+//
+// Recommended noisefmax: At least 2× the input clock frequency
+//
+// ============================================================================
+//
+// Description:
+//   A digitally controlled delay element with 8-bit control resolution.
+//   Models delay variation and phase noise contributions from inverter stages.
+//   Suitable for DLL, PLL, and general clock distribution applications.
+//
+// Operation:
+//   - Input clock (clk_in) is delayed by a digitally programmable amount
+//   - 8-bit control word (dl_ctrl) sets the delay: 0 = minimum, 255 = maximum
+//   - Delay ranges from delay_offset to (delay_offset + 255 × delay_gain)
+//   - Phase noise from inverters is modeled and added as timing jitter
+//
+// Delay Characteristics:
+//   - Resolution: 8-bit control (256 delay steps)
+//   - Delay Range: delay_offset to delay_offset + delay_gain × 255
+//   - Default Range: 10ps to 265ps (1ps per LSB)
+//   - Transfer Function: Delay = delay_offset + delay_gain × ctrl_value + jitter
+//
+// Noise Modeling:
+//   - White Noise: Flat phase noise floor, filtered at Nyquist frequency
+//   - Flicker Noise: 1/f phase noise contribution
+//   - Both scaled by inverter_count to model cumulative stage effects
+//   - Converted to time-domain jitter: Δt = Δφ / (2π × f_clk)
+//
+// Ports:
+//   clk_in   - Input, clock signal to be delayed (electrical)
+//   dl_ctrl  - Input, 8-bit digital control bus [7:0] (electrical)
+//              LSB at bit 0, MSB at bit 7; higher value = longer delay
+//   clk_out  - Output, delayed clock signal (electrical)
+//
+// Parameters:
+//   vdd                       - Supply voltage (default: 0.75V)
+//   delay_gain                - Delay per LSB of control word (default: 1ps)
+//   delay_offset              - Minimum delay at ctrl=0 (default: 10ps)
+//   inverter_count            - Number of inverter stages for noise scaling (default: 4)
+//   clock_frequency           - Input clock frequency for noise modeling (default: 8GHz)
+//   white_noise_floor_dBcHz   - White phase noise floor per inverter (default: -160 dBc/Hz)
+//   flicker_noise_1Hz_dBcHz   - Flicker phase noise at 1Hz per inverter (default: -109 dBc/Hz)
+//
+// ============================================================================
+
+`include "constants.vams"
+`include "disciplines.vams"
+
+`define DCDL_CTRL_BITWIDTH 8
+module dcdl(clk_in, dl_ctrl, clk_out);
+    input clk_in; electrical clk_in;
+    input [(`DCDL_CTRL_BITWIDTH-1):0] dl_ctrl; electrical [(`DCDL_CTRL_BITWIDTH-1):0] dl_ctrl;
+    output clk_out; electrical clk_out;
+
+    parameter real vdd = 0.75;
+    parameter real delay_gain = 1p; // delay per LSB of control word
+    parameter real delay_offset = 10p; // base delay
+    parameter real inverter_count = 4; // number of inverters in the delay line, used to model noise
+    parameter real clock_frequency = 8G; // frequency of the input clock
+    parameter real white_noise_floor_dBcHz = -160; // white phase noise floor introduced by one single inverter
+    parameter real flicker_noise_1Hz_dBcHz = -109; // flicker phase noise at 1Hz offset introduced by one single inverter
+
+    real ctrl_value;
+    real white_noise_floor_linear;
+    real white_noise_td;
+    real white_noise_filtered;
+    real flicker_noise_1Hz_linear;
+    real flicker_noise_td;
+    real total_phase_noise;
+    real total_time_noise;
+    real delay_max;
+    
+    genvar i;
+
+    analog begin
+        // model the phase noise introduced by the DCDL
+        // model one single inverter, then scale the noise by inverter count
+        white_noise_floor_linear = 10**(white_noise_floor_dBcHz/10);
+        white_noise_td = white_noise(inverter_count * white_noise_floor_linear);
+        // filter the white noise at Nyquist frequency to prevent folding
+        white_noise_filtered = laplace_nd(white_noise_td, {1.0}, {1.0, 1.0/(`M_PI*clock_frequency)});
+        flicker_noise_1Hz_linear = 10**(flicker_noise_1Hz_dBcHz/10);
+        flicker_noise_td = flicker_noise(inverter_count * flicker_noise_1Hz_linear, 1);
+        total_phase_noise = white_noise_filtered + flicker_noise_td;
+        total_time_noise = total_phase_noise / (2 * `M_PI * clock_frequency);
+        
+        delay_max = delay_gain * (2**`DCDL_CTRL_BITWIDTH - 1) + delay_offset;
+        
+        // Convert digital bus to numeric value using generate for loop
+        ctrl_value = 0;
+        for (i = 0; i < `DCDL_CTRL_BITWIDTH; i = i + 1) begin
+            ctrl_value = ctrl_value + V(dl_ctrl[i]) * pow(2, i);
+        end
+        
+        V(clk_out) <+ absdelay(V(clk_in), delay_offset + delay_gain * ctrl_value + total_time_noise, delay_max);
+    end
+
+
+endmodule

--- a/verilog/dcdl.vams
+++ b/verilog/dcdl.vams
@@ -11,13 +11,13 @@
 // accuracy, enable transient noise in Spectre simulations.
 //
 // To enable transient noise in Spectre:
-//   1. In ADE: Simulation → Options → Analog → Set "noisefmax" parameter
+//   1. In ADE: Simulation  Options  Analog  Set "noisefmax" parameter
 //      Example: noisefmax=64G (should exceed clock_frequency)
 //   2. In netlist: Add "noisefmax=64G" to the transient analysis statement
 //      Example: tran tran stop=100n noisefmax=64G
 //   3. Command line: spectre +aps netlist.scs +noisefmax=64G
 //
-// Recommended noisefmax: At least 2× the input clock frequency
+// Recommended noisefmax: At least 2 the input clock frequency
 //
 // ============================================================================
 //
@@ -29,20 +29,20 @@
 // Operation:
 //   - Input clock (clk_in) is delayed by a digitally programmable amount
 //   - 8-bit control word (dl_ctrl) sets the delay: 0 = minimum, 255 = maximum
-//   - Delay ranges from delay_offset to (delay_offset + 255 × delay_gain)
+//   - Delay ranges from delay_offset to (delay_offset + 255  delay_gain)
 //   - Phase noise from inverters is modeled and added as timing jitter
 //
 // Delay Characteristics:
 //   - Resolution: 8-bit control (256 delay steps)
-//   - Delay Range: delay_offset to delay_offset + delay_gain × 255
+//   - Delay Range: delay_offset to delay_offset + delay_gain  255
 //   - Default Range: 10ps to 265ps (1ps per LSB)
-//   - Transfer Function: Delay = delay_offset + delay_gain × ctrl_value + jitter
+//   - Transfer Function: Delay = delay_offset + delay_gain  ctrl_value + jitter
 //
 // Noise Modeling:
 //   - White Noise: Flat phase noise floor, filtered at Nyquist frequency
 //   - Flicker Noise: 1/f phase noise contribution
 //   - Both scaled by inverter_count to model cumulative stage effects
-//   - Converted to time-domain jitter: Δt = Δφ / (2π × f_clk)
+//   - Converted to time-domain jitter: t =  / (2  f_clk)
 //
 // Ports:
 //   clk_in   - Input, clock signal to be delayed (electrical)
@@ -107,7 +107,7 @@ module dcdl(clk_in, dl_ctrl, clk_out);
         // Convert digital bus to numeric value using generate for loop
         ctrl_value = 0;
         for (i = 0; i < `DCDL_CTRL_BITWIDTH; i = i + 1) begin
-            ctrl_value = ctrl_value + V(dl_ctrl[i]) * pow(2, i);
+            ctrl_value = ctrl_value + (V(dl_ctrl[i]) > vdd / 2) * pow(2, i);
         end
         
         V(clk_out) <+ absdelay(V(clk_in), delay_offset + delay_gain * ctrl_value + total_time_noise, delay_max);

--- a/verilog/s2d.vams
+++ b/verilog/s2d.vams
@@ -1,0 +1,139 @@
+// ============================================================================
+// Single-to-Differential (S2D) Converter - Verilog-A Behavioral Model
+// ============================================================================
+//
+// ============================================================================
+// NOTE: TRANSIENT NOISE RECOMMENDED FOR REALISTIC JITTER SIMULATION
+// ============================================================================
+//
+// This S2D model includes phase noise modeling (white + flicker noise) for
+// both differential outputs to simulate realistic timing jitter. For best
+// accuracy, enable transient noise in Spectre simulations.
+//
+// To enable transient noise in Spectre:
+//   1. In ADE: Simulation → Options → Analog → Set "noisefmax" parameter
+//      Example: noisefmax=64G (should exceed clock_frequency)
+//   2. In netlist: Add "noisefmax=64G" to the transient analysis statement
+//      Example: tran tran stop=100n noisefmax=64G
+//   3. Command line: spectre +aps netlist.scs +noisefmax=64G
+//
+// Recommended noisefmax: At least 2× the input clock frequency
+//
+// ============================================================================
+//
+// Description:
+//   A single-ended to differential clock converter with realistic phase noise
+//   and mismatch modeling. Converts a single-ended clock input into true
+//   differential outputs (clk_outp and clk_outn) with independent noise sources
+//   and static path mismatch to model manufacturing variations.
+//
+// Operation:
+//   - Single-ended input clock (clk_in) is converted to differential outputs
+//   - clk_outp follows clk_in with processing delay + noise
+//   - clk_outn is the inverted output (VDD - clk_in) with processing delay + noise
+//   - Each path has independent phase noise (white + flicker)
+//   - Static random mismatch between paths models manufacturing variation
+//
+// Differential Path Characteristics:
+//   - Processing Delay: Nominal delay through the converter (default: 20ps)
+//   - Path Mismatch: Random static timing offset between P and N paths
+//   - Maximum Phase Unbalance: User-specified in degrees (default: 5°)
+//   - Time Unbalance: Converted from phase: Δt = φ / (360° × f_clk)
+//   - Mismatch is randomized per simulation instance (manufacturing variation)
+//
+// Noise Modeling:
+//   - Independent noise sources for each differential path (P and N)
+//   - White Noise: Flat phase noise floor, filtered at Nyquist frequency
+//   - Flicker Noise: 1/f phase noise contribution
+//   - Both scaled by inverter_count to model cumulative stage effects
+//   - Converted to time-domain jitter: Δt = Δφ / (2π × f_clk)
+//
+// Ports:
+//   clk_in   - Input, single-ended clock signal (electrical)
+//   clk_outp - Output, positive differential clock output (electrical)
+//   clk_outn - Output, negative differential clock output (electrical)
+//              Inverted version of clk_in
+//
+// Parameters:
+//   vdd                       - Supply voltage (default: 0.75V)
+//   delay                     - Processing delay through converter (default: 20ps)
+//   max_phase_unbalance       - Maximum phase mismatch in degrees (default: 5°)
+//   clock_frequency           - Input clock frequency for noise modeling (default: 8GHz)
+//   inverter_count            - Number of inverter stages per path for noise scaling (default: 2)
+//   white_noise_floor_dBcHz   - White phase noise floor per inverter (default: -160 dBc/Hz)
+//   flicker_noise_1Hz_dBcHz   - Flicker phase noise at 1Hz per inverter (default: -109 dBc/Hz)
+//
+// ============================================================================
+
+`include "constants.vams"
+`include "disciplines.vams"
+
+module s2d(clk_in, clk_outp, clk_outn);
+    input clk_in; electrical clk_in;
+    output clk_outp; electrical clk_outp;
+    output clk_outn; electrical clk_outn;
+
+    parameter real vdd = 0.75;
+    parameter real delay = 20p; // processing delay
+    parameter real max_phase_unbalance = 5; // maximum phase unbalance in degrees
+    parameter real clock_frequency = 8G; // input clock frequency
+    parameter real inverter_count = 2; // number of inverters in each output path, used to model noise
+    parameter real white_noise_floor_dBcHz = -160; // white phase noise floor introduced by one single inverter
+    parameter real flicker_noise_1Hz_dBcHz = -109; // flicker phase noise at 1Hz offset introduced by one single inverter
+
+    real max_time_unbalance;
+    real random_unbalance;
+    integer seed;
+    real white_noise_floor_linear;
+    real white_noise_td_p, white_noise_td_n;
+    real white_noise_filtered_p, white_noise_filtered_n;
+    real flicker_noise_1Hz_linear;
+    real flicker_noise_td_p, flicker_noise_td_n;
+    real total_phase_noise_p, total_phase_noise_n;
+    real total_time_noise_p, total_time_noise_n;
+    real delay_max;
+
+    analog begin
+        // Calculate maximum time unbalance from phase unbalance
+        max_time_unbalance = max_phase_unbalance / 360.0 / clock_frequency;
+        
+        // Initialize random seed once at start based on current time
+        @(initial_step) begin
+            seed = $random + $abstime * 1e12;  // Use $random and timestamp to create unique seed
+        end
+        
+        // Model the phase noise introduced by the S2D for positive output
+        // Model one single inverter, then scale the noise by inverter count
+        white_noise_floor_linear = 10**(white_noise_floor_dBcHz/10);
+        white_noise_td_p = white_noise(inverter_count * white_noise_floor_linear);
+        white_noise_td_n = white_noise(inverter_count * white_noise_floor_linear);
+        
+        // Filter the white noise at Nyquist frequency to prevent folding
+        white_noise_filtered_p = laplace_nd(white_noise_td_p, {1.0}, {1.0, 1.0/(`M_PI*clock_frequency)});
+        white_noise_filtered_n = laplace_nd(white_noise_td_n, {1.0}, {1.0, 1.0/(`M_PI*clock_frequency)});
+        
+        flicker_noise_1Hz_linear = 10**(flicker_noise_1Hz_dBcHz/10);
+        flicker_noise_td_p = flicker_noise(inverter_count * flicker_noise_1Hz_linear, 1);
+        flicker_noise_td_n = flicker_noise(inverter_count * flicker_noise_1Hz_linear, 1);
+        
+        total_phase_noise_p = white_noise_filtered_p + flicker_noise_td_p;
+        total_phase_noise_n = white_noise_filtered_n + flicker_noise_td_n;
+        
+        total_time_noise_p = total_phase_noise_p / (2 * `M_PI * clock_frequency);
+        total_time_noise_n = total_phase_noise_n / (2 * `M_PI * clock_frequency);
+        
+        delay_max = delay + max_time_unbalance;
+        
+        // Generate random unbalance for differential path mismatch (static, set at initialization)
+        @(initial_step) begin
+            random_unbalance = $rdist_uniform(seed, -max_time_unbalance, max_time_unbalance);
+        end
+        
+        // Apply delays with phase noise to both outputs
+        V(clk_outp) <+ absdelay(V(clk_in), delay + random_unbalance + total_time_noise_p, delay_max);
+        V(clk_outn) <+ absdelay(vdd - V(clk_in), delay - random_unbalance + total_time_noise_n, delay_max);
+    end
+
+
+
+endmodule

--- a/verilog/s2d.vams
+++ b/verilog/s2d.vams
@@ -22,46 +22,70 @@
 // ============================================================================
 //
 // Description:
-//   A single-ended to differential clock converter with realistic phase noise
-//   and mismatch modeling. Converts a single-ended clock input into true
-//   differential outputs (clk_outp and clk_outn) with independent noise sources
-//   and static path mismatch to model manufacturing variations.
+//   A single-ended to differential clock converter with edge-triggered
+//   regeneration, realistic phase noise modeling, and path mismatch. Converts
+//   a single-ended clock input into true differential outputs (clk_outp and
+//   clk_outn) with independent noise sources and static manufacturing mismatch.
+//
+// IMPORTANT - Output Waveform Behavior:
+//   This model uses EDGE-TRIGGERED regeneration - it detects rising/falling
+//   edges of the input and generates corresponding delayed transitions at both
+//   differential outputs. The output waveform shapes are synthesized with
+//   controlled parameters, NOT copied from input.
+//   
+//   This means:
+//   - Input timing (edge positions) IS preserved (with delay + jitter + mismatch)
+//   - Input waveform shape (slew rate, amplitude) IS NOT preserved
+//   - Outputs have clean rail-to-rail transitions with controlled slew rate
+//   - Each differential path has independent noise and path delay
+//   - Suitable for clock distribution where timing accuracy matters
 //
 // Operation:
-//   - Single-ended input clock (clk_in) is converted to differential outputs
-//   - clk_outp follows clk_in with processing delay + noise
-//   - clk_outn is the inverted output (VDD - clk_in) with processing delay + noise
-//   - Each path has independent phase noise (white + flicker)
-//   - Static random mismatch between paths models manufacturing variation
+//   1. Input rising edge detected → clk_outp rises, clk_outn falls (after delays)
+//   2. Input falling edge detected → clk_outp falls, clk_outn rises (after delays)
+//   3. Each path has: delay + random_mismatch ± jitter_sampled
+//   4. Jitter sampled at each input edge (both rising and falling)
+//   5. Path mismatch is static (randomized once at initialization)
 //
 // Differential Path Characteristics:
-//   - Processing Delay: Nominal delay through the converter (default: 20ps)
-//   - Path Mismatch: Random static timing offset between P and N paths
+//   - Processing Delay: Nominal delay through converter (default: 20ps)
+//   - Static Path Mismatch: Random timing offset between P and N paths
+//     • Randomized at initialization to model manufacturing variation
+//     • Sampled from uniform distribution: ±max_time_unbalance
+//     • Derived from max_phase_unbalance parameter
 //   - Maximum Phase Unbalance: User-specified in degrees (default: 5°)
-//   - Time Unbalance: Converted from phase: Δt = φ / (360° × f_clk)
-//   - Mismatch is randomized per simulation instance (manufacturing variation)
+//   - Time Unbalance Conversion: Δt = max_phase_unbalance / (360° × f_clk)
 //
 // Noise Modeling:
 //   - Independent noise sources for each differential path (P and N)
 //   - White Noise: Flat phase noise floor, filtered at Nyquist frequency
 //   - Flicker Noise: 1/f phase noise contribution
-//   - Both scaled by inverter_count to model cumulative stage effects
-//   - Converted to time-domain jitter: Δt = Δφ / (2π × f_clk)
+//   - Noise scaled by inverter_count to model cumulative stage effects
+//   - Phase noise converted to timing jitter: Δt = Δφ / (2π × f_clk)
+//   - Jitter sampled at each input edge transition (discrete, sample-and-hold)
+//   - Each edge gets new independent jitter samples for both paths
 //
 // Ports:
 //   clk_in   - Input, single-ended clock signal (electrical)
+//              Only edge timing is used; waveform shape is ignored
 //   clk_outp - Output, positive differential clock output (electrical)
+//              Rail-to-rail signal (0 to vdd) with controlled slew rate
+//              Follows clk_in: high when input high, low when input low
 //   clk_outn - Output, negative differential clock output (electrical)
-//              Inverted version of clk_in
+//              Rail-to-rail signal (0 to vdd) with controlled slew rate
+//              Inverted from clk_in: low when input high, high when input low
 //
 // Parameters:
-//   vdd                       - Supply voltage (default: 0.75V)
-//   delay                     - Processing delay through converter (default: 20ps)
-//   max_phase_unbalance       - Maximum phase mismatch in degrees (default: 5°)
+//   vdd                       - Supply voltage / output signal amplitude (default: 0.75V)
+//   delay                     - Nominal processing delay through converter (default: 20ps)
+//   t_slew                    - Output transition (rise/fall) time (default: 5ps)
+//   max_phase_unbalance       - Maximum static phase mismatch in degrees (default: 5°)
+//                               Converted to time: ±max_phase_unbalance/(360×f_clk)
 //   clock_frequency           - Input clock frequency for noise modeling (default: 8GHz)
-//   inverter_count            - Number of inverter stages per path for noise scaling (default: 2)
-//   white_noise_floor_dBcHz   - White phase noise floor per inverter (default: -160 dBc/Hz)
-//   flicker_noise_1Hz_dBcHz   - Flicker phase noise at 1Hz per inverter (default: -109 dBc/Hz)
+//   inverter_count            - Number of inverter stages per path (default: 2)
+//                               Higher count = more cumulative noise
+//   white_noise_floor_dBcHz   - White phase noise floor per single inverter (default: -160 dBc/Hz)
+//   flicker_noise_1Hz_dBcHz   - Flicker phase noise at 1Hz offset per inverter (default: -109 dBc/Hz)
 //
 // ============================================================================
 
@@ -80,6 +104,7 @@ module s2d(clk_in, clk_outp, clk_outn);
     parameter real inverter_count = 2; // number of inverters in each output path, used to model noise
     parameter real white_noise_floor_dBcHz = -160; // white phase noise floor introduced by one single inverter
     parameter real flicker_noise_1Hz_dBcHz = -109; // flicker phase noise at 1Hz offset introduced by one single inverter
+    parameter real t_slew = 5p; // output transition time
 
     real max_time_unbalance;
     real random_unbalance;
@@ -90,19 +115,22 @@ module s2d(clk_in, clk_outp, clk_outn);
     real flicker_noise_1Hz_linear;
     real flicker_noise_td_p, flicker_noise_td_n;
     real total_phase_noise_p, total_phase_noise_n;
-    real total_time_noise_p, total_time_noise_n;
+    real total_time_noise_sampled_p = 0, total_time_noise_sampled_n = 0;  // Sampled jitter for each path
     real delay_max;
+    integer sign_p = 0, sign_n = 1;  // Track differential output states
 
     analog begin
-        // Calculate maximum time unbalance from phase unbalance
-        max_time_unbalance = max_phase_unbalance / 360.0 / clock_frequency;
-        
         // Initialize random seed once at start based on current time
         @(initial_step) begin
             seed = $random + $abstime * 1e12;  // Use $random and timestamp to create unique seed
+            total_time_noise_sampled_p = 0;
+            total_time_noise_sampled_n = 0;
         end
         
-        // Model the phase noise introduced by the S2D for positive output
+        // Calculate maximum time unbalance from phase unbalance
+        max_time_unbalance = max_phase_unbalance / 360.0 / clock_frequency;
+        
+        // Model the phase noise introduced by the S2D for both outputs
         // Model one single inverter, then scale the noise by inverter count
         white_noise_floor_linear = 10**(white_noise_floor_dBcHz/10);
         white_noise_td_p = white_noise(inverter_count * white_noise_floor_linear);
@@ -119,8 +147,11 @@ module s2d(clk_in, clk_outp, clk_outn);
         total_phase_noise_p = white_noise_filtered_p + flicker_noise_td_p;
         total_phase_noise_n = white_noise_filtered_n + flicker_noise_td_n;
         
-        total_time_noise_p = total_phase_noise_p / (2 * `M_PI * clock_frequency);
-        total_time_noise_n = total_phase_noise_n / (2 * `M_PI * clock_frequency);
+        // Sample noise at each input edge transition (both rising and falling)
+        @(cross(V(clk_in) - vdd/2, 0)) begin
+            total_time_noise_sampled_p = total_phase_noise_p / (2 * `M_PI * clock_frequency);
+            total_time_noise_sampled_n = total_phase_noise_n / (2 * `M_PI * clock_frequency);
+        end
         
         delay_max = delay + max_time_unbalance;
         
@@ -129,9 +160,19 @@ module s2d(clk_in, clk_outp, clk_outn);
             random_unbalance = $rdist_uniform(seed, -max_time_unbalance, max_time_unbalance);
         end
         
-        // Apply delays with phase noise to both outputs
-        V(clk_outp) <+ absdelay(V(clk_in), delay + random_unbalance + total_time_noise_p, delay_max);
-        V(clk_outn) <+ absdelay(vdd - V(clk_in), delay - random_unbalance + total_time_noise_n, delay_max);
+        // Detect input edges and toggle differential outputs
+        @(cross(V(clk_in) - vdd/2, 1)) begin
+            sign_p = 1;
+            sign_n = 0;
+        end
+        @(cross(V(clk_in) - vdd/2, -1)) begin
+            sign_p = 0;
+            sign_n = 1;
+        end
+        
+        // Generate differential outputs with sampled noise
+        V(clk_outp) <+ transition(vdd * sign_p, delay + random_unbalance + total_time_noise_sampled_p - t_slew / 2, t_slew);
+        V(clk_outn) <+ transition(vdd * sign_n, delay - random_unbalance + total_time_noise_sampled_n - t_slew / 2, t_slew);
     end
 
 


### PR DESCRIPTION
Add digitally controlled delay line (DCDL) and single-to-differential (S2D) 
converter models for clock distribution with comprehensive phase noise modeling.

DCDL (dcdl.vams):
- 8-bit digital control (256 steps, 1ps/LSB default)
- Delay range: 10ps-265ps configurable
- White + flicker noise scaled by inverter count
- Edge-triggered regeneration with sample-and-hold jitter

S2D (s2d.vams):
- Single-ended to differential clock conversion
- Independent noise per differential path (P/N)
- Static path mismatch modeling (±5° default)
- Edge-triggered with rail-to-rail outputs

Validation:
- Phase noise analysis performed - matches theoretical models
- Jitter characteristics verified in transient simulations

Note: Requires transient noise enabled (noisefmax ≥ 2× clock frequency).

Phase noise has been measured and compared against theoretical calculation. Matched result is shown below, with a jitter standard deviation of 14.12fs (one single inverter phase noise profile).
<img width="972" height="571" alt="image" src="https://github.com/user-attachments/assets/d0808875-b125-47f5-a44e-1e477340ef35" />

