### PR TITLE
Support multi-beat transactions

### DIFF
--- a/scala/src/tilelink/Codegen.scala
+++ b/scala/src/tilelink/Codegen.scala
@@ -251,7 +251,7 @@ object Codegen {
   lazy val ucieRegmap: Seq[(Int, Seq[RegField])] = {
     implicit val p = Parameters.empty
     val ucie_dut = new RTLHarness(
-      new UcieTL(ucieParams, Seq(AddressSet(0x0, 0xffffL)), 32)
+      new UcieTL(ucieParams, Seq(AddressSet(0x0, 0xffffL)), 32, 32)
     )
     val ucie = (new chisel3.stage.phases.Elaborate)
       .transform(Seq(chisel3.stage.ChiselGeneratorAnnotation { () =>

--- a/scala/src/tilelink/TileLink.scala
+++ b/scala/src/tilelink/TileLink.scala
@@ -571,7 +571,7 @@ class UcieTXD(creditBits: Int = 5) extends Bundle {
   val tl = new UcieTLBundleD
 }
 
-class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: Int)(implicit
+class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: Int, blockBytes: Int)(implicit
     p: Parameters
 ) extends LazyModule {
   override lazy val desiredName = "UcieTL"
@@ -592,9 +592,9 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
             regionType =
               RegionType.UNCACHED, // Should be changed to CACHED eventually
             executable = true,
-            supportsGet = TransferSizes(1, beatBytes),
-            supportsPutFull = TransferSizes(1, beatBytes),
-            supportsPutPartial = TransferSizes(1, beatBytes),
+            supportsGet = TransferSizes(1, blockBytes),
+            supportsPutFull = TransferSizes(1, blockBytes),
+            supportsPutPartial = TransferSizes(1, blockBytes),
             fifoId = Some(0)
           )
         },
@@ -901,7 +901,7 @@ trait CanHavePeripheryUcieTL { this: BaseSubsystem =>
   val uciephy = p(UcieTLKey) match {
     case Some(params) => {
       val uciephy =
-        params.map(x => LazyModule(new UcieTL(x, Seq(AddressSet(0x0, 0xffffL)), pbus.beatBytes)(p)))
+        params.map(x => LazyModule(new UcieTL(x, Seq(AddressSet(0x0, 0xffffL)), pbus.beatBytes, pbus.blockBytes)(p)))
 
       lazy val uciephy_tlbus =
         params.map(x => locateTLBusWrapper(x.managerWhere))
@@ -927,7 +927,7 @@ trait CanHavePeripheryUcieTL { this: BaseSubsystem =>
 }
 
 class UcieChipletLink(val params: UcieTLParams, val sys_params: OffchipSubsystemParams, val id: Int)(implicit p: Parameters) extends ChipletLinkWrapper {
-  val ucie = LazyModule(new UcieTL(params, sys_params.managerRegion, sys_params.managerBeatBytes)(p))
+  val ucie = LazyModule(new UcieTL(params, sys_params.managerRegion, sys_params.managerBeatBytes, sys_params.managerBlockBytes)(p))
   val client_node = ucie.clientNode
   val manager_node = ucie.managerNode
   val control_manager_node = Some(ucie.regNode)

--- a/scala/test/src/tilelink/TileLinkSpec.scala
+++ b/scala/test/src/tilelink/TileLinkSpec.scala
@@ -314,6 +314,7 @@ class TestHarness(implicit p: Parameters, includeDefaultModels: Boolean = true)
     new UcieTL(
       UcieTLParams(includeDefaultModels = includeDefaultModels, maxInflight = 1),
       Seq(AddressSet(0x0, 0xffffL)),
+      TestHarness.beatBytes,
       TestHarness.beatBytes
     )
   )
@@ -429,6 +430,7 @@ class ScalaTestHarness(
         maxInflight = mbMaxInflight
       ),
       Seq(AddressSet(0x0, 0xffffL)),
+      TestHarness.beatBytes,
       TestHarness.beatBytes
     )
   )
@@ -567,7 +569,7 @@ class TileLinkSpec extends AnyFunSpec with ChiselSim {
     it("should generate valid SystemVerilog") {
       implicit val p = Parameters.empty
       ChiselStage.emitSystemVerilogFile(
-        LazyModule(new RTLHarness(new UcieTL(UcieTLParams(), Seq(AddressSet(0x0, 0xffffL)), 32))).module,
+        LazyModule(new RTLHarness(new UcieTL(UcieTLParams(), Seq(AddressSet(0x0, 0xffffL)), 32, 32))).module,
         args = Array(
           "--target-dir",
           (Utils.buildRoot / "UcieTL_should_generate_valid_SystemVerilog").toString


### PR DESCRIPTION
This matches how serial TL handles bursts.

It is legal for the receiver to lower ready in between beats, so there is no need to check for credit availability for the entire burst. IMO there would be a higher risk of there being a bug when checking credit availability than there is of the sending node having spec-noncompliant behavior.