### PR TITLE
Add control reg for credit flow

### DIFF
--- a/scala/src/tilelink/Credit.scala
+++ b/scala/src/tilelink/Credit.scala
@@ -8,6 +8,7 @@ class CreditCounter(counter_size: Int, buffer_depth: Int) extends Module {
         val avail = Output(Bool())
         val used = Input(Bool())
         val ret = Flipped(Valid(UInt(log2Up(buffer_depth).W)))
+        val mode = Input(Bool()) // If false, reset counter values to default (credit flow disabled)
     })
 
     val cred_used = RegInit(0.U(log2Up(counter_size).W))
@@ -16,11 +17,11 @@ class CreditCounter(counter_size: Int, buffer_depth: Int) extends Module {
 
 
     when (io.used) {
-        cred_used := cred_used + 1.U
+        cred_used := Mux(io.mode, cred_used + 1.U, 0.U)
     }
 
     when (io.ret.valid) {
-        cred_gnt := cred_gnt + io.ret.bits
+        cred_gnt := Mux(io.mode, cred_gnt + io.ret.bits, buffer_depth.U)
     }
 
     overflow := cred_gnt - cred_used

--- a/scala/src/tilelink/TileLink.scala
+++ b/scala/src/tilelink/TileLink.scala
@@ -124,6 +124,7 @@ class UcieTLRegsIO(
   )
   val phy = Flipped(new PhyRegsIO(numLanes))
   val mainbandSel = Output(MainbandSel())
+  val creditFlowEnable = Output(Bool())
 }
 
 class UcieTLRegs(params: UcieTLParams, beatBytes: Int)(implicit
@@ -326,6 +327,9 @@ class UcieTLRegs(params: UcieTLParams, beatBytes: Int)(implicit
       val mainbandSel = RegInit(MainbandSel.phytest)
       io.mainbandSel := mainbandSel
 
+      val creditFlowEnable = RegInit(true.B)
+      io.creditFlowEnable := creditFlowEnable
+
       txFsmRst.ready := true.B
       txExecute.ready := true.B
       txWriteChunk.ready := true.B
@@ -515,7 +519,8 @@ class UcieTLRegs(params: UcieTLParams, beatBytes: Int)(implicit
       ) ++ Seq(
         toRegFieldRw(txValid, "txValid"),
         toRegFieldRw(rxLfsrValid, "rxLfsrValid"),
-        toRegFieldRw(mainbandSel, "mainbandSel")
+        toRegFieldRw(mainbandSel, "mainbandSel"),
+        toRegFieldRw(creditFlowEnable, "creditFlowEnable")
       )
 
       mmioRegs.zipWithIndex.map({
@@ -881,12 +886,14 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
       aCreditCounter.io.used := managerTl.a.fire
       aCreditCounter.io.ret.valid := creditAValid || creditDValid
       aCreditCounter.io.ret.bits := Mux(creditAValid, rxABuffer.io.deq.bits.credit_a, rxDBuffer.io.deq.bits.credit_a)
+      aCreditCounter.io.mode := regs.module.io.creditFlowEnable
       aAvail := aCreditCounter.io.avail
 
       val dCreditCounter = Module(new CreditCounter(params.creditCounterSize, params.tlBufferDepth))
       dCreditCounter.io.used := clientTl.d.fire
       dCreditCounter.io.ret.valid := creditAValid || creditDValid
       dCreditCounter.io.ret.bits := Mux(creditAValid, rxABuffer.io.deq.bits.credit_d, rxDBuffer.io.deq.bits.credit_d)
+      dCreditCounter.io.mode := regs.module.io.creditFlowEnable
       dAvail := dCreditCounter.io.avail
     }
   }


### PR DESCRIPTION
Adds an MMIO register to turn off the credit flow control and push all transactions through regardless of queue space.
Modes can be switched at runtime, but credit counting is fully disabled (i.e. counter values are forced to their default) when the mode reg is low, so the queues should be allowed to drain first before switching modes.