### PR TITLE
UCIe integration into TileLink.scala

### DIFF
--- a/scala/src/tilelink/TileLink.scala
+++ b/scala/src/tilelink/TileLink.scala
@@ -666,7 +666,6 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
     }
     io.debug <> test.io.bumps
     test.io.debug <> phy.io.debug
-    test.io.sb <> phy.io.sb
     phy.io.clkRst.divResetb := test.io.divResetb
     test.io.regs <> regs.module.io.test
 
@@ -722,9 +721,19 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
         test.io.rx.bits := rxTestFifo.io.deq.bits
         test.io.rx.valid := rxTestFifo.io.deq.valid && !selUcie
         rxTestFifo.io.deq.ready := Mux(selUcie, digiToPhyRx.ready, test.io.rx.ready)
+
+        // Sideband: ucie mode uses ucieDigital; phytest/tl use PhyTest. Rx goes to both.
+        val digiSb = ucieDigital.io.phyFacingIo.sidebandLink
+        phy.io.sb.txClk  := Mux(selUcie, digiSb.out.fwClock.asClock, test.io.sb.txClk)
+        phy.io.sb.txData := Mux(selUcie, digiSb.out.bits.asBool, test.io.sb.txData)
+        test.io.sb.rxClk  := phy.io.sb.rxClk
+        test.io.sb.rxData := phy.io.sb.rxData
+        digiSb.in.bits    := phy.io.sb.rxData.asUInt
+        digiSb.in.fwClock := phy.io.sb.rxClk.asUInt
       case None =>
         txTestFifo.io.enq <> test.io.tx
         rxTestFifo.io.deq <> test.io.rx
+        test.io.sb <> phy.io.sb
     }
 
     withClockAndReset(childClock, childReset) {

--- a/scala/src/tilelink/TileLink.scala
+++ b/scala/src/tilelink/TileLink.scala
@@ -17,6 +17,7 @@ import freechips.rocketchip.regmapper.{RegField, RegWriteFn, RegFieldDesc}
 import freechips.rocketchip.tilelink._
 import edu.berkeley.cs.uciedigital.phy._
 import edu.berkeley.cs.uciedigital.top.{UcieDigitalTop, UcieDigitalTopParams}
+import edu.berkeley.cs.uciedigital.regs.{UcieRegBlock, UcieRegBlockIO, UcieRegParams, AdapterToRegs, PhyToRegs, LinkToRegs, MailboxSbResp, PhyToVendor}
 import edu.berkeley.cs.chippy._
 import freechips.rocketchip.diplomacy.{SimpleDevice, AddressSet}
 import org.chipsalliance.diplomacy._
@@ -32,7 +33,7 @@ import freechips.rocketchip.diplomacy.BundleBridgeSource
 import testchipip.soc.{ChipletLinkParams, ChipletLinkWrapperInstantiationLike, ChipletLinkWrapper, OffchipSubsystemParams, ChipletIO}
 
 case class UcieTLParams(
-    address: BigInt = 0x4000,
+    address: BigInt = 0x200000,
     bufferDepthPerLane: Int = 11,
     numLanes: Int = 16,
     bitCounterWidth: Int = 64,
@@ -42,7 +43,7 @@ case class UcieTLParams(
     queueParams: AsyncQueueParams = AsyncQueueParams(depth = 32),
     maxInflight: Int = 1,
     includeDefaultModels: Boolean = false,
-    ucieRegsBaseAddress: BigInt = 0x20000
+    ucieRegsBaseAddress: BigInt = 0x40000
 ) extends ChipletLinkParams
  with ChipletLinkWrapperInstantiationLike 
  {
@@ -130,7 +131,7 @@ class UcieTLRegsIO(
   val mainbandSel = Output(MainbandSel())
 }
 
-class UcieTLRegs(params: UcieTLParams, beatBytes: Int)(implicit
+class UcieTLRegs(params: UcieTLParams, beatBytes: Int, ucieRegParams: UcieRegParams)(implicit
     p: Parameters
 ) extends ClockSinkDomain(ClockSinkParameters()) {
   def toRegFieldRw[T <: Data](r: T, name: String): RegField = {
@@ -149,9 +150,10 @@ class UcieTLRegs(params: UcieTLParams, beatBytes: Int)(implicit
   def toRegFieldR[T <: Data](r: T, name: String): RegField = {
     RegField.r(r.getWidth, r.asUInt, RegFieldDesc(name, ""))
   }
+  val ucieTLRegionSize = 0x4000
   val device = new SimpleDevice("ucie_control", Seq("ucbbar,ucie"))
   val node = TLRegisterNode(
-    Seq(AddressSet(params.address, 16384 - 1)),
+    Seq(AddressSet(params.address, ucieTLRegionSize + ucieRegParams.allocation.regionSize - 1)),
     device,
     "reg/control",
     beatBytes = beatBytes
@@ -166,6 +168,8 @@ class UcieTLRegs(params: UcieTLParams, beatBytes: Int)(implicit
         params.bitCounterWidth
       )
     )
+    
+    val ucieBlockIo = IO(new UcieRegBlockIO(ucieRegParams))
 
     val regmap = withClockAndReset(clock, reset) {
       // TODO: Remove and add necessary registers
@@ -528,7 +532,13 @@ class UcieTLRegs(params: UcieTLParams, beatBytes: Int)(implicit
         }
       })
     }
-    node.regmap(regmap: _*)
+
+    // Spec-defined UCIe digital registers. Added after UCIe TL Regs.
+    val ucieRegmap = withClockAndReset(clock, reset) {
+      val (entries, _, _) = UcieRegBlock.build(ucieBlockIo, reset, ucieRegParams, ucieTLRegionSize)
+      entries
+    }
+    node.regmap((regmap ++ ucieRegmap): _*)
   }
 }
 
@@ -583,7 +593,16 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
   // Main digital clock node.
   val digitalClockNode = ClockSinkNode(Seq(ClockSinkParameters()))
   val ucieDigitalClockNode = ClockSourceNode(Seq(ClockSourceParameters()))
-  val regs = LazyModule(new UcieTLRegs(params, beatBytes))
+
+  val ucieRegParams = UcieDigitalTopParams.default().regs.copy(
+    baseAddress = params.ucieRegsBaseAddress,
+    numModules = 1,
+    includeRegNode = false,
+    includeInterruptNode = false
+  )
+  val ucieDigitalLazy: UcieDigitalTop =
+    LazyModule(new UcieDigitalTop(UcieDigitalTopParams.default().copy(regs = ucieRegParams)))
+  val regs = LazyModule(new UcieTLRegs(params, beatBytes, ucieRegParams))
 
   val device = new SimpleDevice("ucie", Seq("ucbbar,ucie"))
   // Manager node to send and acquire traffic to partner die
@@ -621,16 +640,6 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
   )
   val regNode = regs.node
   regs.clockNode := ucieDigitalClockNode
-
-  val ucieDigitalLazy: UcieDigitalTop = {
-    val baseParams = UcieDigitalTopParams.default()
-    val regParams = baseParams.regs.copy(
-      baseAddress = params.ucieRegsBaseAddress,
-      numModules = 1,
-      diplomaticIntRouting = false
-    )
-      LazyModule(new UcieDigitalTop(baseParams.copy(regs = regParams)))
-   }
 
   override lazy val module = new UcieTLImpl
   class UcieTLImpl extends LazyRawModuleImp(this) {
@@ -690,9 +699,10 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
     rxTestFifo.io.deq_reset := phy.io.clkRst.ucieRst
 
   
-    val ucieDigital = withClockAndReset(phy.io.clkRst.ucieClk, phy.io.clkRst.ucieRst) { 
-      ucieDigitalLazy.module 
+    val ucieDigital = withClockAndReset(phy.io.clkRst.ucieClk, phy.io.clkRst.ucieRst) {
+      ucieDigitalLazy.module
     }
+    ucieDigital.io.regBlockIo.foreach { rb => regs.module.ucieBlockIo <> rb }
     val selUcie = mainbandSel === MainbandSel.ucie
     // phyFacing TX: mux PhyTest vs ucieDigital into txTestFifo.enq (both ucieClk).
     val digiToPhyTx = ucieDigital.io.phyFacingIo.mainbandLink.tx
@@ -1016,14 +1026,6 @@ class UcieChipletLink(val params: UcieTLParams, val sys_params: OffchipSubsystem
   val client_node = ucie.clientNode
   val manager_node = ucie.managerNode
   val control_manager_node = Some(ucie.regNode)
-  // UcieRegTop MMIO node, interrupt source.
-  // TODO(for Ella): in testchipip OffchipRouter/CanHaveChipletRouting, expose the port wrappers and
-  // can make CanHaveUcieDigitalRegAndIntNodes and connect them to buses with that,
-  // or override a val here and connect them to buses in CanHaveChipletRouting instead.
-  //   ucie_reg_node -> cbus  (node := TLWidthWidget(cbus.beatBytes) := TLBuffer() := _)
-  //   ucie_int_node -> ibus  (ibus.fromAsync := _)   [after flipping diplomaticIntRouting to true]
-  val ucie_reg_node = ucie.ucieDigitalLazy.regNode
-  val ucie_int_node = ucie.ucieDigitalLazy.intNode
   val clock_node = Some(ucie.digitalClockNode)
   val top_IO = BundleBridgeSource(() => new UcieBumpsIO(params.numLanes))
   override lazy val module = new UcieChipletLinkImpl(this)

--- a/scala/src/tilelink/TileLink.scala
+++ b/scala/src/tilelink/TileLink.scala
@@ -724,7 +724,7 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
 
         // Sideband: ucie mode uses ucieDigital; phytest/tl use PhyTest. Rx goes to both.
         val digiSb = ucieDigital.io.phyFacingIo.sidebandLink
-        phy.io.sb.txClk  := Mux(selUcie, digiSb.out.fwClock.asClock, test.io.sb.txClk)
+        phy.io.sb.txClk  := Mux(selUcie, digiSb.out.fwClock.asBool.asClock, test.io.sb.txClk)
         phy.io.sb.txData := Mux(selUcie, digiSb.out.bits.asBool, test.io.sb.txData)
         test.io.sb.rxClk  := phy.io.sb.rxClk
         test.io.sb.rxData := phy.io.sb.rxData

--- a/scala/src/tilelink/TileLink.scala
+++ b/scala/src/tilelink/TileLink.scala
@@ -42,7 +42,6 @@ case class UcieTLParams(
     queueParams: AsyncQueueParams = AsyncQueueParams(depth = 32),
     maxInflight: Int = 1,
     includeDefaultModels: Boolean = false,
-    includeUcieDigital: Boolean = false,
     ucieRegsBaseAddress: BigInt = 0x20000
 ) extends ChipletLinkParams
  with ChipletLinkWrapperInstantiationLike 
@@ -623,16 +622,15 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
   val regNode = regs.node
   regs.clockNode := ucieDigitalClockNode
 
-  val ucieDigital: Option[UcieDigitalTop] =
-    if (params.includeUcieDigital) {
-      val baseParams = UcieDigitalTopParams.default()
-      val regParams = baseParams.regs.copy(
-        baseAddress = params.ucieRegsBaseAddress,
-        numModules = 1,
-        diplomaticIntRouting = false
-      )
-      Some(LazyModule(new UcieDigitalTop(baseParams.copy(regs = regParams))))
-    } else None
+  val ucieDigitalLazy: UcieDigitalTop = {
+    val baseParams = UcieDigitalTopParams.default()
+    val regParams = baseParams.regs.copy(
+      baseAddress = params.ucieRegsBaseAddress,
+      numModules = 1,
+      diplomaticIntRouting = false
+    )
+      LazyModule(new UcieDigitalTop(baseParams.copy(regs = regParams)))
+   }
 
   override lazy val module = new UcieTLImpl
   class UcieTLImpl extends LazyRawModuleImp(this) {
@@ -691,51 +689,47 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
     rxTestFifo.io.deq_clock := phy.io.clkRst.ucieClk
     rxTestFifo.io.deq_reset := phy.io.clkRst.ucieRst
 
-    ucieDigital match {
-      case Some(lm) =>
-        val ucieDigital = withClockAndReset(phy.io.clkRst.ucieClk, phy.io.clkRst.ucieRst) { lm.module }
-        val selUcie = mainbandSel === MainbandSel.ucie
-        // phyFacing TX: mux PhyTest vs ucieDigital into txTestFifo.enq (both ucieClk).
-        val digiToPhyTx = ucieDigital.io.phyFacingIo.mainbandLink.tx
-        val digiTxAsTxIo = Wire(new TxIO(params.numLanes))
-        digiTxAsTxIo.data := digiToPhyTx.bits.data
-        digiTxAsTxIo.valid := digiToPhyTx.bits.valid
-        digiTxAsTxIo.clkp := digiToPhyTx.bits.clkP
-        digiTxAsTxIo.clkn := digiToPhyTx.bits.clkN
-        digiTxAsTxIo.track := digiToPhyTx.bits.trk
-        txTestFifo.io.enq.valid := Mux(selUcie, digiToPhyTx.valid, test.io.tx.valid)
-        txTestFifo.io.enq.bits := Mux(selUcie, digiTxAsTxIo, test.io.tx.bits)
-        test.io.tx.ready := txTestFifo.io.enq.ready && !selUcie
-        digiToPhyTx.ready := txTestFifo.io.enq.ready && selUcie
-
-        // phyFacing RX: rxTestFifo.deq routed to PhyTest or ucieDigital by sel.
-        val digiToPhyRx = ucieDigital.io.phyFacingIo.mainbandLink.rx
-        digiToPhyRx.bits.data := rxTestFifo.io.deq.bits.data
-        digiToPhyRx.bits.valid := rxTestFifo.io.deq.bits.valid
-        digiToPhyRx.bits.trk := rxTestFifo.io.deq.bits.track
-        // TODO: RxIO has no clkp/clkn; use the forwarded-clock patterns until sampled clkP/clkN exist.
-        // Need them for training and link bringup.
-        digiToPhyRx.bits.clkP := "h55555555".U
-        digiToPhyRx.bits.clkN := "haaaaaaaa".U
-        digiToPhyRx.valid := rxTestFifo.io.deq.valid && selUcie
-        test.io.rx.bits := rxTestFifo.io.deq.bits
-        test.io.rx.valid := rxTestFifo.io.deq.valid && !selUcie
-        rxTestFifo.io.deq.ready := Mux(selUcie, digiToPhyRx.ready, test.io.rx.ready)
-
-        // Sideband: ucie mode uses ucieDigital; phytest/tl use PhyTest. Rx goes to both.
-        val digiSb = ucieDigital.io.phyFacingIo.sidebandLink
-        phy.io.sb.txClk  := Mux(selUcie, digiSb.out.fwClock.asBool.asClock, test.io.sb.txClk)
-        phy.io.sb.txData := Mux(selUcie, digiSb.out.bits.asBool, test.io.sb.txData)
-        test.io.sb.rxClk  := phy.io.sb.rxClk
-        test.io.sb.rxData := phy.io.sb.rxData
-        digiSb.in.bits    := phy.io.sb.rxData.asUInt
-        digiSb.in.fwClock := phy.io.sb.rxClk.asUInt
-      case None =>
-        txTestFifo.io.enq <> test.io.tx
-        rxTestFifo.io.deq <> test.io.rx
-        test.io.sb <> phy.io.sb
+  
+    val ucieDigital = withClockAndReset(phy.io.clkRst.ucieClk, phy.io.clkRst.ucieRst) { 
+      ucieDigitalLazy.module 
     }
+    val selUcie = mainbandSel === MainbandSel.ucie
+    // phyFacing TX: mux PhyTest vs ucieDigital into txTestFifo.enq (both ucieClk).
+    val digiToPhyTx = ucieDigital.io.phyFacingIo.mainbandLink.tx
+    val digiTxAsTxIo = Wire(new TxIO(params.numLanes))
+    digiTxAsTxIo.data := digiToPhyTx.bits.data
+    digiTxAsTxIo.valid := digiToPhyTx.bits.valid
+    digiTxAsTxIo.clkp := digiToPhyTx.bits.clkP
+    digiTxAsTxIo.clkn := digiToPhyTx.bits.clkN
+    digiTxAsTxIo.track := digiToPhyTx.bits.trk
+    txTestFifo.io.enq.valid := Mux(selUcie, digiToPhyTx.valid, test.io.tx.valid)
+    txTestFifo.io.enq.bits := Mux(selUcie, digiTxAsTxIo, test.io.tx.bits)
+    test.io.tx.ready := txTestFifo.io.enq.ready && !selUcie
+    digiToPhyTx.ready := txTestFifo.io.enq.ready && selUcie
 
+    // phyFacing RX: rxTestFifo.deq routed to PhyTest or ucieDigital by sel.
+    val digiToPhyRx = ucieDigital.io.phyFacingIo.mainbandLink.rx
+    digiToPhyRx.bits.data := rxTestFifo.io.deq.bits.data
+    digiToPhyRx.bits.valid := rxTestFifo.io.deq.bits.valid
+    digiToPhyRx.bits.trk := rxTestFifo.io.deq.bits.track
+    // TODO: RxIO has no clkp/clkn; use the forwarded-clock patterns until sampled clkP/clkN exist.
+    // Need them for training and link bringup.
+    digiToPhyRx.bits.clkP := "h55555555".U
+    digiToPhyRx.bits.clkN := "haaaaaaaa".U
+    digiToPhyRx.valid := rxTestFifo.io.deq.valid && selUcie
+    test.io.rx.bits := rxTestFifo.io.deq.bits
+    test.io.rx.valid := rxTestFifo.io.deq.valid && !selUcie
+    rxTestFifo.io.deq.ready := Mux(selUcie, digiToPhyRx.ready, test.io.rx.ready)
+
+    // Sideband: ucie mode uses ucieDigital; phytest/tl use PhyTest. Rx goes to both.
+    val digiSb = ucieDigital.io.phyFacingIo.sidebandLink
+    phy.io.sb.txClk  := Mux(selUcie, digiSb.out.fwClock.asBool.asClock, test.io.sb.txClk)
+    phy.io.sb.txData := Mux(selUcie, digiSb.out.bits.asBool, test.io.sb.txData)
+    test.io.sb.rxClk  := phy.io.sb.rxClk
+    test.io.sb.rxData := phy.io.sb.rxData
+    digiSb.in.bits    := phy.io.sb.rxData.asUInt
+    digiSb.in.fwClock := phy.io.sb.rxClk.asUInt
+     
     withClockAndReset(childClock, childReset) {
       val clientTl = clientNode.out(0)._1
       val managerTl = managerNode.in(0)._1
@@ -826,7 +820,7 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
       val txTlFifo =
         Module(new AsyncQueue(new TxIO(params.numLanes), params.queueParams))
       // Always true to send clock when tl path.
-      txTlFifo.io.enq.valid := (if (params.includeUcieDigital) (mainbandSel === MainbandSel.tl) else true.B)
+      txTlFifo.io.enq.valid := mainbandSel === MainbandSel.tl
       val txValid = clientTl.d.fire || managerTl.a.fire || creditRetValid
       txTlFifo.io.enq.bits.track := "h55555555".U
       txTlFifo.io.enq.bits.clkp := "h55555555".U
@@ -841,25 +835,18 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
 
       // chipFacing TX: route the same framed data into ucieDigital (ucie mode), crossing
       // childClock -> ucieClk. Only the protocol data crosses (no track/clkp/clkn/valid lanes); deq is ucieClk.
-      val chipFacingTxFifo = ucieDigital.map { lm =>
-        val ucieDigital = lm.module
-        val txAQ = Module(new AsyncQueue(chiselTypeOf(ucieDigital.io.chipFacingIo.mainbandTx.bits), params.queueParams))
-        txAQ.io.enq.valid := mainbandSel === MainbandSel.ucie
-        txAQ.io.enq.bits.data := txFramedData.asTypeOf(txAQ.io.enq.bits.data)
-        txAQ.io.enq_clock := childClock
-        txAQ.io.enq_reset := childReset
-        txAQ.io.deq_clock := phy.io.clkRst.ucieClk
-        txAQ.io.deq_reset := phy.io.clkRst.ucieRst
-        ucieDigital.io.chipFacingIo.mainbandTx.valid := txAQ.io.deq.valid
-        ucieDigital.io.chipFacingIo.mainbandTx.bits := txAQ.io.deq.bits
-        txAQ.io.deq.ready := ucieDigital.io.chipFacingIo.mainbandTx.ready
-        txAQ
-      }
-
-      val txEnqReady = chipFacingTxFifo match {
-        case Some(txAQ) => Mux(mainbandSel === MainbandSel.ucie, txAQ.io.enq.ready, txTlFifo.io.enq.ready)
-        case None       => txTlFifo.io.enq.ready
-      }
+      val txAQ = Module(new AsyncQueue(chiselTypeOf(ucieDigital.io.chipFacingIo.mainbandTx.bits), params.queueParams))
+      txAQ.io.enq.valid := mainbandSel === MainbandSel.ucie
+      txAQ.io.enq.bits.data := txFramedData.asTypeOf(txAQ.io.enq.bits.data)
+      txAQ.io.enq_clock := childClock
+      txAQ.io.enq_reset := childReset
+      txAQ.io.deq_clock := phy.io.clkRst.ucieClk
+      txAQ.io.deq_reset := phy.io.clkRst.ucieRst
+      ucieDigital.io.chipFacingIo.mainbandTx.valid := txAQ.io.deq.valid
+      ucieDigital.io.chipFacingIo.mainbandTx.bits := txAQ.io.deq.bits
+      txAQ.io.deq.ready := ucieDigital.io.chipFacingIo.mainbandTx.ready
+      val txEnqReady = Mux(mainbandSel === MainbandSel.ucie, txAQ.io.enq.ready, txTlFifo.io.enq.ready)
+    
       clientTl.d.ready := txEnqReady && dAvail
       managerTl.a.ready := txEnqReady && aAvail && !clientTl.d.valid
 
@@ -899,28 +886,18 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
 
       // chipFacing RX: ucieDigital's 512b (ucie mode) feeds the credit path, crossing
       // ucieClk -> childClock. Muxed with the tl-path ValidFramer output by mainbandSel.
-      val chipFacingRxFifo = ucieDigital.map { lm =>
-        val ucieDigital = lm.module
-        val rxAQ = Module(new AsyncQueue(chiselTypeOf(ucieDigital.io.chipFacingIo.mainbandRx.bits), params.queueParams))
-        rxAQ.io.enq.valid := ucieDigital.io.chipFacingIo.mainbandRx.valid && (mainbandSel === MainbandSel.ucie)
-        rxAQ.io.enq.bits := ucieDigital.io.chipFacingIo.mainbandRx.bits
-        ucieDigital.io.chipFacingIo.mainbandRx.ready := rxAQ.io.enq.ready && (mainbandSel === MainbandSel.ucie)
-        rxAQ.io.enq_clock := phy.io.clkRst.ucieClk
-        rxAQ.io.enq_reset := phy.io.clkRst.ucieRst
-        rxAQ.io.deq_clock := childClock
-        rxAQ.io.deq_reset := childReset
-        rxAQ.io.deq.ready := mainbandSel === MainbandSel.ucie
-        rxAQ
-      }
+      val rxAQ = Module(new AsyncQueue(chiselTypeOf(ucieDigital.io.chipFacingIo.mainbandRx.bits), params.queueParams))
+      rxAQ.io.enq.valid := ucieDigital.io.chipFacingIo.mainbandRx.valid && (mainbandSel === MainbandSel.ucie)
+      rxAQ.io.enq.bits := ucieDigital.io.chipFacingIo.mainbandRx.bits
+      ucieDigital.io.chipFacingIo.mainbandRx.ready := rxAQ.io.enq.ready && (mainbandSel === MainbandSel.ucie)
+      rxAQ.io.enq_clock := phy.io.clkRst.ucieClk
+      rxAQ.io.enq_reset := phy.io.clkRst.ucieRst
+      rxAQ.io.deq_clock := childClock
+      rxAQ.io.deq_reset := childReset
+      rxAQ.io.deq.ready := mainbandSel === MainbandSel.ucie
+      val framedBits = Mux(mainbandSel === MainbandSel.ucie, rxAQ.io.deq.bits.data, validFramer.io.digital.bits.asUInt)
+      val framedValid = Mux(mainbandSel === MainbandSel.ucie, rxAQ.io.deq.valid, validFramer.io.digital.valid)
 
-      val framedBits = chipFacingRxFifo match {
-        case Some(rxAQ) => Mux(mainbandSel === MainbandSel.ucie, rxAQ.io.deq.bits.data, validFramer.io.digital.bits.asUInt)
-        case None       => validFramer.io.digital.bits.asUInt
-      }
-      val framedValid = chipFacingRxFifo match {
-        case Some(rxAQ) => Mux(mainbandSel === MainbandSel.ucie, rxAQ.io.deq.valid, validFramer.io.digital.valid)
-        case None       => validFramer.io.digital.valid
-      }
       val tlBits = framedBits(framedBits.getWidth - 1, 1)
       rxABuffer.io.enq.bits := tlBits.asTypeOf(rxABuffer.io.enq.bits)
       rxDBuffer.io.enq.bits := tlBits.asTypeOf(rxDBuffer.io.enq.bits)
@@ -1039,14 +1016,14 @@ class UcieChipletLink(val params: UcieTLParams, val sys_params: OffchipSubsystem
   val client_node = ucie.clientNode
   val manager_node = ucie.managerNode
   val control_manager_node = Some(ucie.regNode)
-  // UcieRegTop MMIO node, interrupt source (present only when includeUcieDigital).
+  // UcieRegTop MMIO node, interrupt source.
   // TODO(for Ella): in testchipip OffchipRouter/CanHaveChipletRouting, expose the port wrappers and
   // can make CanHaveUcieDigitalRegAndIntNodes and connect them to buses with that,
   // or override a val here and connect them to buses in CanHaveChipletRouting instead.
   //   ucie_reg_node -> cbus  (node := TLWidthWidget(cbus.beatBytes) := TLBuffer() := _)
   //   ucie_int_node -> ibus  (ibus.fromAsync := _)   [after flipping diplomaticIntRouting to true]
-  val ucie_reg_node = ucie.ucieDigital.map(_.regNode)
-  val ucie_int_node = ucie.ucieDigital.flatMap(_.intNode)
+  val ucie_reg_node = ucie.ucieDigitalLazy.regNode
+  val ucie_int_node = ucie.ucieDigitalLazy.intNode
   val clock_node = Some(ucie.digitalClockNode)
   val top_IO = BundleBridgeSource(() => new UcieBumpsIO(params.numLanes))
   override lazy val module = new UcieChipletLinkImpl(this)

--- a/scala/src/tilelink/TileLink.scala
+++ b/scala/src/tilelink/TileLink.scala
@@ -16,6 +16,7 @@ import org.chipsalliance.cde.config.{Parameters, Field, Config}
 import freechips.rocketchip.regmapper.{RegField, RegWriteFn, RegFieldDesc}
 import freechips.rocketchip.tilelink._
 import edu.berkeley.cs.uciedigital.phy._
+import edu.berkeley.cs.uciedigital.top.{UcieDigitalTop, UcieDigitalTopParams}
 import edu.berkeley.cs.chippy._
 import freechips.rocketchip.diplomacy.{SimpleDevice, AddressSet}
 import org.chipsalliance.diplomacy._
@@ -40,7 +41,9 @@ case class UcieTLParams(
     managerWhere: TLBusWrapperLocation = PBUS,
     queueParams: AsyncQueueParams = AsyncQueueParams(depth = 32),
     maxInflight: Int = 1,
-    includeDefaultModels: Boolean = false
+    includeDefaultModels: Boolean = false,
+    includeUcieDigital: Boolean = false,
+    ucieRegsBaseAddress: BigInt = 0x20000
 ) extends ChipletLinkParams
  with ChipletLinkWrapperInstantiationLike 
  {
@@ -109,9 +112,11 @@ class UcieBumpsIO(numLanes: Int = 16) extends ChipletIO {
 
 object MainbandSel extends ChiselEnum {
   // Allow PhyTest to control mainband
-  val phytest = Value(0.U(1.W))
+  val phytest = Value(0.U(2.W))
   // Send TL packets over mainband
-  val tl = Value(1.U(1.W))
+  val tl = Value(1.U(2.W))
+  // Route mainband through the UCIe digital controller (UcieDigitalTop)
+  val ucie = Value(2.U(2.W))
 }
 
 class UcieTLRegsIO(
@@ -618,6 +623,17 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
   val regNode = regs.node
   regs.clockNode := ucieDigitalClockNode
 
+  val ucieDigital: Option[UcieDigitalTop] =
+    if (params.includeUcieDigital) {
+      val baseParams = UcieDigitalTopParams.default()
+      val regParams = baseParams.regs.copy(
+        baseAddress = params.ucieRegsBaseAddress,
+        numModules = 1,
+        diplomaticIntRouting = false
+      )
+      Some(LazyModule(new UcieDigitalTop(baseParams.copy(regs = regParams))))
+    } else None
+
   override lazy val module = new UcieTLImpl
   class UcieTLImpl extends LazyRawModuleImp(this) {
     childClock := digitalClockNode.in(0)._1.clock
@@ -654,26 +670,62 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
     phy.io.clkRst.divResetb := test.io.divResetb
     test.io.regs <> regs.module.io.test
 
+    val mainbandSel = regs.module.io.mainbandSel
+
     // Async crossings
     val txTestFifo =
       Module(new AsyncQueue(new TxIO(params.numLanes), params.queueParams))
-    txTestFifo.io.enq <> test.io.tx
     txTestFifo.io.enq_clock := phy.io.clkRst.ucieClk
     txTestFifo.io.enq_reset := phy.io.clkRst.ucieRst
     txTestFifo.io.deq_clock := phy.io.clkRst.txDivClk
     txTestFifo.io.deq_reset := phy.io.clkRst.txDivRst
     // TODO: should deq ready be synchronous to deq clock?
-    txTestFifo.io.deq.ready := regs.module.io.mainbandSel === MainbandSel.phytest
+    // txTestFifo crosses both the phytest and ucie mainband tx signals to the PHY.
+    txTestFifo.io.deq.ready := mainbandSel =/= MainbandSel.tl
 
     val rxTestFifo =
       Module(new AsyncQueue(new RxIO(params.numLanes), params.queueParams))
     rxTestFifo.io.enq.bits := phy.io.rx
-    rxTestFifo.io.enq.valid := regs.module.io.mainbandSel === MainbandSel.phytest
+    rxTestFifo.io.enq.valid := mainbandSel =/= MainbandSel.tl
     rxTestFifo.io.enq_clock := phy.io.clkRst.rxDivClk
     rxTestFifo.io.enq_reset := phy.io.clkRst.rxDivRst
-    rxTestFifo.io.deq <> test.io.rx
     rxTestFifo.io.deq_clock := phy.io.clkRst.ucieClk
     rxTestFifo.io.deq_reset := phy.io.clkRst.ucieRst
+
+    ucieDigital match {
+      case Some(lm) =>
+        val ucieDigital = withClockAndReset(phy.io.clkRst.ucieClk, phy.io.clkRst.ucieRst) { lm.module }
+        val selUcie = mainbandSel === MainbandSel.ucie
+        // phyFacing TX: mux PhyTest vs ucieDigital into txTestFifo.enq (both ucieClk).
+        val digiToPhyTx = ucieDigital.io.phyFacingIo.mainbandLink.tx
+        val digiTxAsTxIo = Wire(new TxIO(params.numLanes))
+        digiTxAsTxIo.data := digiToPhyTx.bits.data
+        digiTxAsTxIo.valid := digiToPhyTx.bits.valid
+        digiTxAsTxIo.clkp := digiToPhyTx.bits.clkP
+        digiTxAsTxIo.clkn := digiToPhyTx.bits.clkN
+        digiTxAsTxIo.track := digiToPhyTx.bits.trk
+        txTestFifo.io.enq.valid := Mux(selUcie, digiToPhyTx.valid, test.io.tx.valid)
+        txTestFifo.io.enq.bits := Mux(selUcie, digiTxAsTxIo, test.io.tx.bits)
+        test.io.tx.ready := txTestFifo.io.enq.ready && !selUcie
+        digiToPhyTx.ready := txTestFifo.io.enq.ready && selUcie
+
+        // phyFacing RX: rxTestFifo.deq routed to PhyTest or ucieDigital by sel.
+        val digiToPhyRx = ucieDigital.io.phyFacingIo.mainbandLink.rx
+        digiToPhyRx.bits.data := rxTestFifo.io.deq.bits.data
+        digiToPhyRx.bits.valid := rxTestFifo.io.deq.bits.valid
+        digiToPhyRx.bits.trk := rxTestFifo.io.deq.bits.track
+        // TODO: RxIO has no clkp/clkn; use the forwarded-clock patterns until sampled clkP/clkN exist.
+        // Need them for training and link bringup.
+        digiToPhyRx.bits.clkP := "h55555555".U
+        digiToPhyRx.bits.clkN := "haaaaaaaa".U
+        digiToPhyRx.valid := rxTestFifo.io.deq.valid && selUcie
+        test.io.rx.bits := rxTestFifo.io.deq.bits
+        test.io.rx.valid := rxTestFifo.io.deq.valid && !selUcie
+        rxTestFifo.io.deq.ready := Mux(selUcie, digiToPhyRx.ready, test.io.rx.ready)
+      case None =>
+        txTestFifo.io.enq <> test.io.tx
+        rxTestFifo.io.deq <> test.io.rx
+    }
 
     withClockAndReset(childClock, childReset) {
       val clientTl = clientNode.out(0)._1
@@ -736,7 +788,7 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
       val dAvail = Wire(Bool())
 
       creditRetTimer := creditRetTimer + 1.U
-      creditRetValid := (creditRetTimer === 127.U || aCreditsToReturn > 15.U || dCreditsToReturn > 15.U) && regs.module.io.mainbandSel === MainbandSel.tl
+      creditRetValid := (creditRetTimer === 127.U || aCreditsToReturn > 15.U || dCreditsToReturn > 15.U) && regs.module.io.mainbandSel =/= MainbandSel.phytest
 
       val ucieClientTxD = Wire(new UcieTXD(creditBits))
       ucieClientTxD.tl_valid := clientTl.d.fire
@@ -764,21 +816,43 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
       val rxDBuffer = Module(new Queue(new UcieTXD(creditBits), params.tlBufferDepth))
       val txTlFifo =
         Module(new AsyncQueue(new TxIO(params.numLanes), params.queueParams))
-      // Always true to send clock.
-      txTlFifo.io.enq.valid := true.B
+      // Always true to send clock when tl path.
+      txTlFifo.io.enq.valid := (if (params.includeUcieDigital) (mainbandSel === MainbandSel.tl) else true.B)
       val txValid = clientTl.d.fire || managerTl.a.fire || creditRetValid
       txTlFifo.io.enq.bits.track := "h55555555".U
       txTlFifo.io.enq.bits.clkp := "h55555555".U
       txTlFifo.io.enq.bits.clkn := "haaaaaaaa".U
       txTlFifo.io.enq.bits.valid := Mux(txValid, "h0000ffff".U, 0.U)
-      txTlFifo.io.enq.bits.data := Mux(
+      val txFramedData = Mux(
         clientTl.d.valid,
         Cat(ucieClientTxD.asUInt, 1.U),
         Cat(ucieManagerTxA.asUInt, 0.U)
-      ).asTypeOf(txTlFifo.io.enq.bits.data)
+      )
+      txTlFifo.io.enq.bits.data := txFramedData.asTypeOf(txTlFifo.io.enq.bits.data)
 
-      clientTl.d.ready := txTlFifo.io.enq.ready && dAvail
-      managerTl.a.ready := txTlFifo.io.enq.ready && aAvail && !clientTl.d.valid
+      // chipFacing TX: route the same framed data into ucieDigital (ucie mode), crossing
+      // childClock -> ucieClk. Only the protocol data crosses (no track/clkp/clkn/valid lanes); deq is ucieClk.
+      val chipFacingTxFifo = ucieDigital.map { lm =>
+        val ucieDigital = lm.module
+        val txAQ = Module(new AsyncQueue(chiselTypeOf(ucieDigital.io.chipFacingIo.mainbandTx.bits), params.queueParams))
+        txAQ.io.enq.valid := mainbandSel === MainbandSel.ucie
+        txAQ.io.enq.bits.data := txFramedData.asTypeOf(txAQ.io.enq.bits.data)
+        txAQ.io.enq_clock := childClock
+        txAQ.io.enq_reset := childReset
+        txAQ.io.deq_clock := phy.io.clkRst.ucieClk
+        txAQ.io.deq_reset := phy.io.clkRst.ucieRst
+        ucieDigital.io.chipFacingIo.mainbandTx.valid := txAQ.io.deq.valid
+        ucieDigital.io.chipFacingIo.mainbandTx.bits := txAQ.io.deq.bits
+        txAQ.io.deq.ready := ucieDigital.io.chipFacingIo.mainbandTx.ready
+        txAQ
+      }
+
+      val txEnqReady = chipFacingTxFifo match {
+        case Some(txAQ) => Mux(mainbandSel === MainbandSel.ucie, txAQ.io.enq.ready, txTlFifo.io.enq.ready)
+        case None       => txTlFifo.io.enq.ready
+      }
+      clientTl.d.ready := txEnqReady && dAvail
+      managerTl.a.ready := txEnqReady && aAvail && !clientTl.d.valid
 
       when(rxABuffer.io.deq.fire) {
         aCreditsToReturn := aCreditsToReturn + 1.U
@@ -803,7 +877,7 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
         Module(new AsyncQueue(new RxIO(params.numLanes), params.queueParams))
       val validFramer = Module(new ValidFramer(params.numLanes))
       rxTlFifo.io.enq.bits := phy.io.rx
-      rxTlFifo.io.enq.valid := regs.module.io.mainbandSel === MainbandSel.tl
+      rxTlFifo.io.enq.valid := mainbandSel === MainbandSel.tl
       rxTlFifo.io.enq_clock := phy.io.clkRst.rxDivClk
       rxTlFifo.io.enq_reset := phy.io.clkRst.rxDivRst
       rxTlFifo.io.deq <> validFramer.io.phy
@@ -813,11 +887,35 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
       validFramer.io.digital.ready := true.B
       rxABuffer.io.enq.valid := false.B
       rxDBuffer.io.enq.valid := false.B
-      val framedBits = validFramer.io.digital.bits.asUInt
+
+      // chipFacing RX: ucieDigital's 512b (ucie mode) feeds the credit path, crossing
+      // ucieClk -> childClock. Muxed with the tl-path ValidFramer output by mainbandSel.
+      val chipFacingRxFifo = ucieDigital.map { lm =>
+        val ucieDigital = lm.module
+        val rxAQ = Module(new AsyncQueue(chiselTypeOf(ucieDigital.io.chipFacingIo.mainbandRx.bits), params.queueParams))
+        rxAQ.io.enq.valid := ucieDigital.io.chipFacingIo.mainbandRx.valid && (mainbandSel === MainbandSel.ucie)
+        rxAQ.io.enq.bits := ucieDigital.io.chipFacingIo.mainbandRx.bits
+        ucieDigital.io.chipFacingIo.mainbandRx.ready := rxAQ.io.enq.ready && (mainbandSel === MainbandSel.ucie)
+        rxAQ.io.enq_clock := phy.io.clkRst.ucieClk
+        rxAQ.io.enq_reset := phy.io.clkRst.ucieRst
+        rxAQ.io.deq_clock := childClock
+        rxAQ.io.deq_reset := childReset
+        rxAQ.io.deq.ready := mainbandSel === MainbandSel.ucie
+        rxAQ
+      }
+
+      val framedBits = chipFacingRxFifo match {
+        case Some(rxAQ) => Mux(mainbandSel === MainbandSel.ucie, rxAQ.io.deq.bits.data, validFramer.io.digital.bits.asUInt)
+        case None       => validFramer.io.digital.bits.asUInt
+      }
+      val framedValid = chipFacingRxFifo match {
+        case Some(rxAQ) => Mux(mainbandSel === MainbandSel.ucie, rxAQ.io.deq.valid, validFramer.io.digital.valid)
+        case None       => validFramer.io.digital.valid
+      }
       val tlBits = framedBits(framedBits.getWidth - 1, 1)
       rxABuffer.io.enq.bits := tlBits.asTypeOf(rxABuffer.io.enq.bits)
       rxDBuffer.io.enq.bits := tlBits.asTypeOf(rxDBuffer.io.enq.bits)
-      when(validFramer.io.digital.valid) {
+      when(framedValid) {
         when(framedBits.asUInt(0)) {
           rxDBuffer.io.enq.valid := true.B
         }.otherwise {
@@ -860,16 +958,17 @@ class UcieTL(params: UcieTLParams, managerRegion: Seq[AddressSet], beatBytes: In
       txContClocks.clkn := "haaaaaaaa".U
       txContClocks.track := "h55555555".U
 
+      // tl mode drives from txTlFifo; phytest and ucie both drive from txTestFifo.
       phy.io.tx := Mux(
-        regs.module.io.mainbandSel === MainbandSel.phytest,
-        Mux(
-          txTestFifo.io.deq.valid,
-          txTestFifo.io.deq.bits,
-          0.U.asTypeOf(phy.io.tx)
-        ),
+        mainbandSel === MainbandSel.tl,
         Mux(
           txTlFifo.io.deq.valid,
           txContClocks,
+          0.U.asTypeOf(phy.io.tx)
+        ),
+        Mux(
+          txTestFifo.io.deq.valid,
+          txTestFifo.io.deq.bits,
           0.U.asTypeOf(phy.io.tx)
         )
       )
@@ -931,6 +1030,14 @@ class UcieChipletLink(val params: UcieTLParams, val sys_params: OffchipSubsystem
   val client_node = ucie.clientNode
   val manager_node = ucie.managerNode
   val control_manager_node = Some(ucie.regNode)
+  // UcieRegTop MMIO node, interrupt source (present only when includeUcieDigital).
+  // TODO(for Ella): in testchipip OffchipRouter/CanHaveChipletRouting, expose the port wrappers and
+  // can make CanHaveUcieDigitalRegAndIntNodes and connect them to buses with that,
+  // or override a val here and connect them to buses in CanHaveChipletRouting instead.
+  //   ucie_reg_node -> cbus  (node := TLWidthWidget(cbus.beatBytes) := TLBuffer() := _)
+  //   ucie_int_node -> ibus  (ibus.fromAsync := _)   [after flipping diplomaticIntRouting to true]
+  val ucie_reg_node = ucie.ucieDigital.map(_.regNode)
+  val ucie_int_node = ucie.ucieDigital.flatMap(_.intNode)
   val clock_node = Some(ucie.digitalClockNode)
   val top_IO = BundleBridgeSource(() => new UcieBumpsIO(params.numLanes))
   override lazy val module = new UcieChipletLinkImpl(this)

--- a/scala/src/uciedigital/regs/UcieRegBlock.scala
+++ b/scala/src/uciedigital/regs/UcieRegBlock.scala
@@ -1,0 +1,55 @@
+// UCIe register-block IO bundle and reg-map builder.
+package edu.berkeley.cs.uciedigital.regs
+
+import chisel3._
+import freechips.rocketchip.regmapper.RegField
+
+class UcieRegBlockIO(params: UcieRegParams) extends Bundle {
+  val linkReset = Input(Bool())
+  val adapterToRegs = Input(new AdapterToRegs)
+  val regsToAdapter = Output(new RegsToAdapter)
+  val phyToRegs = Input(new PhyToRegs(params.numModules))
+  val regsToPhy = Output(new RegsToPhy(params.numModules))
+  val linkToRegs = Input(new LinkToRegs)
+  val regsToLink = Output(new RegsToLink)
+  val mailboxSideband = new MailboxToSideband
+  val vendorToPhy = if (params.hasVendorPhyBlock) Some(Output(new VendorToPhy)) else None
+  val phyToVendor = if (params.hasVendorPhyBlock) Some(Input(new PhyToVendor)) else None
+  val vendorToD2d = if (params.hasVendorD2dBlock) Some(Output(new VendorToD2d)) else None
+  val d2dToVendor = if (params.hasVendorD2dBlock) Some(Input(new D2dToVendor)) else None
+}
+
+object UcieRegBlock {
+  // Builds the register state + fields; `base` offsets the block. Returns the entries and the two IRQ wires.
+  def build(
+      io: UcieRegBlockIO,
+      implicitReset: Reset,
+      params: UcieRegParams,
+      base: BigInt = 0
+  ): (Seq[RegField.Map], Bool, Bool) = {
+    val alloc = params.allocation
+    val (stickyReset, nonStickyReset) = UcieResets(implicitReset, io.linkReset)
+    val f = new RegFieldTypes(stickyReset, nonStickyReset)
+
+    val dvsec = new UcieLinkDvsecRegs(f, io.linkToRegs, io.regsToLink, io.mailboxSideband, params)
+    val adapterMerged = Wire(new AdapterToRegs)
+    adapterMerged := io.adapterToRegs
+    when(dvsec.mailboxHeaderLog1.valid) {
+      adapterMerged.headerLog1.valid := true.B
+      adapterMerged.headerLog1.bits := dvsec.mailboxHeaderLog1.bits
+    }
+    val block =
+      new D2DPhyRegisterBlock(f, adapterMerged, io.regsToAdapter, io.phyToRegs, io.regsToPhy, params)
+
+    val vendorEntries: Seq[RegField.Map] =
+      alloc.phyVendorBase.toSeq.flatMap { b =>
+        new PhyVendorRegBlock(f, params, io.phyToVendor.get, io.vendorToPhy.get).entries(base + b)
+      } ++ alloc.d2dVendorBase.toSeq.flatMap { b =>
+        new D2dVendorRegBlock(f, params, io.d2dToVendor.get, io.vendorToD2d.get).entries(base + b)
+      }
+
+    val entries: Seq[RegField.Map] =
+      dvsec.entries(base + alloc.dvsecBase) ++ block.entries(base + alloc.d2dPhyBase) ++ vendorEntries
+    (entries, dvsec.linkEventIrq, dvsec.linkErrorIrq)
+  }
+}

--- a/scala/src/uciedigital/regs/UcieRegParams.scala
+++ b/scala/src/uciedigital/regs/UcieRegParams.scala
@@ -48,7 +48,8 @@ case class UcieRegParams(
     vendorId: Int = 0xd2de,
     hasVendorPhyBlock: Boolean = true,
     hasVendorD2dBlock: Boolean = false,
-    diplomaticIntRouting: Boolean = false
+    includeRegNode: Boolean = true,
+    includeInterruptNode: Boolean = false
 ) {
   def packageType: UciePackageType.Value = phyCapability.packageType
   require(

--- a/scala/src/uciedigital/regs/UcieRegTop.scala
+++ b/scala/src/uciedigital/regs/UcieRegTop.scala
@@ -9,82 +9,66 @@ import freechips.rocketchip.diplomacy.{AddressSet, SimpleDevice}
 import freechips.rocketchip.tilelink.TLRegisterNode
 import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
 
+// Add the raw IRQ output ports used when interrupts are not routed through a diplomatic node.
+class UcieRegTopIO(params: UcieRegParams) extends UcieRegBlockIO(params) {
+  val linkEventIrq = if (params.includeInterruptNode) None else Some(Output(Bool()))
+  val linkErrorIrq = if (params.includeInterruptNode) None else Some(Output(Bool()))
+}
+
 class UcieRegTop(val params: UcieRegParams, val beatBytes: Int = 4)(implicit p: Parameters)
     extends ClockSinkDomain(ClockSinkParameters()) {
 
-  private val alloc = params.allocation
+  val allocation = params.allocation
 
   val device = new SimpleDevice("ucie-regs", Seq("ucbbar,ucie-regs"))
 
-  val node = TLRegisterNode(
-    address = Seq(AddressSet(params.baseAddress, alloc.regionSize - 1)),
-    device = device,
-    deviceKey = "reg/control",
-    beatBytes = beatBytes,
-    undefZero = true
-  )
+  val node: Option[TLRegisterNode] =
+    if (params.includeRegNode) {
+      Some(TLRegisterNode(
+        address = Seq(AddressSet(params.baseAddress, allocation.regionSize - 1)),
+        device = device,
+        deviceKey = "reg/control",
+        beatBytes = beatBytes,
+        undefZero = true
+      ))
+    } else None
 
   val intNode: Option[IntSourceNode] =
-    if (params.diplomaticIntRouting) {
+    if (params.includeInterruptNode) {
       Some(IntSourceNode(IntSourcePortSimple(num = 1, sources = 2)))
     } else None
 
   override lazy val module = new UcieRegTopImpl
   class UcieRegTopImpl extends Impl {
-    val io = IO(new Bundle {
-      val linkReset = Input(Bool())
-      val adapterToRegs = Input(new AdapterToRegs)
-      val regsToAdapter = Output(new RegsToAdapter)
-      val phyToRegs = Input(new PhyToRegs(params.numModules))
-      val regsToPhy = Output(new RegsToPhy(params.numModules))
-      val linkToRegs = Input(new LinkToRegs)
-      val regsToLink = Output(new RegsToLink)
-      val mailboxSideband = new MailboxToSideband
-      val vendorToPhy = if (params.hasVendorPhyBlock) Some(Output(new VendorToPhy)) else None
-      val phyToVendor = if (params.hasVendorPhyBlock) Some(Input(new PhyToVendor)) else None
-      val vendorToD2d = if (params.hasVendorD2dBlock) Some(Output(new VendorToD2d)) else None
-      val d2dToVendor = if (params.hasVendorD2dBlock) Some(Input(new D2dToVendor)) else None
-      val linkEventIrq = if (params.diplomaticIntRouting) None else Some(Output(Bool()))
-      val linkErrorIrq = if (params.diplomaticIntRouting) None else Some(Output(Bool()))
-    })
+    val io = IO(new UcieRegTopIO(params))
 
     val regMapEntries: Seq[freechips.rocketchip.regmapper.RegField.Map] =
       withClockAndReset(clock, reset) {
-      val (stickyReset, nonStickyReset) = UcieResets(reset, io.linkReset)
-      val f = new RegFieldTypes(stickyReset, nonStickyReset)
-
-      val dvsec = new UcieLinkDvsecRegs(f, io.linkToRegs, io.regsToLink, io.mailboxSideband, params)
-      val adapterMerged = Wire(new AdapterToRegs)
-      adapterMerged := io.adapterToRegs
-      when(dvsec.mailboxHeaderLog1.valid) {
-        adapterMerged.headerLog1.valid := true.B
-        adapterMerged.headerLog1.bits := dvsec.mailboxHeaderLog1.bits
-      }
-      val block =
-        new D2DPhyRegisterBlock(f, adapterMerged, io.regsToAdapter, io.phyToRegs, io.regsToPhy, params)
-
-      val vendorEntries: Seq[freechips.rocketchip.regmapper.RegField.Map] =
-        alloc.phyVendorBase.toSeq.flatMap { base =>
-          new PhyVendorRegBlock(f, params, io.phyToVendor.get, io.vendorToPhy.get).entries(base)
-        } ++ alloc.d2dVendorBase.toSeq.flatMap { base =>
-          new D2dVendorRegBlock(f, params, io.d2dToVendor.get, io.vendorToD2d.get).entries(base)
+        // If no node declared, build the map externally with UcieRegBlock.build
+        if (node.isDefined || intNode.isDefined) {
+          val (entries, linkEventIrq, linkErrorIrq) = UcieRegBlock.build(io, reset, params)
+          node.foreach(_.regmap(entries: _*))
+          intNode match {
+            case Some(intn) =>
+              val (ints, _) = intn.out(0)
+              ints(0) := linkEventIrq
+              ints(1) := linkErrorIrq
+            case None =>
+              io.linkEventIrq.foreach(_ := linkEventIrq)
+              io.linkErrorIrq.foreach(_ := linkErrorIrq)
+          }
+          entries
+        } else {
+          io.regsToAdapter := DontCare
+          io.regsToPhy := DontCare
+          io.regsToLink := DontCare
+          io.mailboxSideband.req := DontCare
+          io.vendorToPhy.foreach(_ := DontCare)
+          io.vendorToD2d.foreach(_ := DontCare)
+          io.linkEventIrq.foreach(_ := false.B)
+          io.linkErrorIrq.foreach(_ := false.B)
+          Seq.empty
         }
-
-      val entries: Seq[freechips.rocketchip.regmapper.RegField.Map] =
-        dvsec.entries(alloc.dvsecBase) ++ block.entries(alloc.d2dPhyBase) ++ vendorEntries
-      node.regmap(entries: _*)
-
-      intNode match {
-        case Some(n) =>
-          val (ints, _) = n.out(0)
-          ints(0) := dvsec.linkEventIrq
-          ints(1) := dvsec.linkErrorIrq
-        case None =>
-          io.linkEventIrq.get := dvsec.linkEventIrq
-          io.linkErrorIrq.get := dvsec.linkErrorIrq
       }
-
-      entries
-    }
   }
 }

--- a/scala/src/uciedigital/top/UcieDigitalTop.scala
+++ b/scala/src/uciedigital/top/UcieDigitalTop.scala
@@ -34,6 +34,7 @@ class UcieDigitalTopPhyIO(afeParams: AfeParams, sbParams: SidebandParams) extend
 class UcieDigitalTopIO(params: UcieDigitalTopParams) extends Bundle {
   val chipFacingIo = new UcieDigitalTopChipIO(params.protocol)
   val phyFacingIo  = new UcieDigitalTopPhyIO(params.logPhy.afe, params.logPhy.sideband)
+  val regBlockIo = if (!params.regs.includeRegNode) Some(Flipped(new UcieRegBlockIO(params.regs))) else None
 }
 
 class UcieDigitalTop(params: UcieDigitalTopParams = UcieDigitalTopParams.default())(implicit p: Parameters)
@@ -41,19 +42,29 @@ class UcieDigitalTop(params: UcieDigitalTopParams = UcieDigitalTopParams.default
   private val validatedParams = params.validate()
   override lazy val desiredName = "UcieDigitalTop"
 
-  val regs = LazyModule(new UcieRegTop(validatedParams.regs))
-  val regNode = regs.node
-  val intNode = regs.intNode
-  private val regClockSource = ClockSourceNode(Seq(ClockSourceParameters()))
-  regs.clockNode := regClockSource
+  // With no node the map is spliced into an outer TLRegisterNode; expose the allocation so it can size it.
+  val ucieRegAllocation = validatedParams.regs.allocation
+  val regs: Option[UcieRegTop] =
+    if (validatedParams.regs.includeRegNode || validatedParams.regs.includeInterruptNode)
+      Some(LazyModule(new UcieRegTop(validatedParams.regs)))
+    else None
+  val regNode = regs.flatMap(_.node)
+  val intNode = regs.flatMap(_.intNode)
+  private val regClockSource = regs.map { r =>
+    val src = ClockSourceNode(Seq(ClockSourceParameters()))
+    r.clockNode := src
+    src
+  }
 
   override lazy val module = new UcieDigitalTopImpl
   class UcieDigitalTopImpl extends LazyModuleImp(this) {
     val io = IO(new UcieDigitalTopIO(validatedParams))
 
-    val (regClk, _) = regClockSource.out(0)
-    regClk.clock := clock
-    regClk.reset := reset
+    regClockSource.foreach { src =>
+      val (regClk, _) = src.out(0)
+      regClk.clock := clock
+      regClk.reset := reset
+    }
 
     val protocolLayer = Module(new ProtocolLayer(
       params = validatedParams.protocol.layer,
@@ -95,21 +106,41 @@ class UcieDigitalTop(params: UcieDigitalTopParams = UcieDigitalTopParams.default
     dontTouch(logicalPhy.io.status)
     dontTouch(logicalPhy.io.analog.ctrl) // logphy->PHY control
 
-    regs.module.io.linkReset := false.B
-    regs.module.io.adapterToRegs := 0.U.asTypeOf(new AdapterToRegs)
-    regs.module.io.phyToRegs := 0.U.asTypeOf(new PhyToRegs(validatedParams.regs.numModules))
-    regs.module.io.linkToRegs := 0.U.asTypeOf(new LinkToRegs)
-    regs.module.io.mailboxSideband.req.ready := true.B
-    regs.module.io.mailboxSideband.resp.valid := false.B
-    regs.module.io.mailboxSideband.resp.bits := 0.U.asTypeOf(new MailboxSbResp)
-    regs.module.io.phyToVendor.foreach(_ := 0.U.asTypeOf(new PhyToVendor))
-    regs.module.io.d2dToVendor.foreach(_ := DontCare)
-    dontTouch(regs.module.io.regsToAdapter)
-    dontTouch(regs.module.io.regsToPhy)
-    dontTouch(regs.module.io.regsToLink)
-    dontTouch(regs.module.io.mailboxSideband.req)
-    regs.module.io.vendorToPhy.foreach(dontTouch(_))
-    regs.module.io.linkEventIrq.foreach(dontTouch(_))
-    regs.module.io.linkErrorIrq.foreach(dontTouch(_))
+    regs.foreach { r =>
+      r.module.io.linkReset := false.B
+      r.module.io.adapterToRegs := 0.U.asTypeOf(new AdapterToRegs)
+      r.module.io.phyToRegs := 0.U.asTypeOf(new PhyToRegs(validatedParams.regs.numModules))
+      r.module.io.linkToRegs := 0.U.asTypeOf(new LinkToRegs)
+      r.module.io.mailboxSideband.req.ready := true.B
+      r.module.io.mailboxSideband.resp.valid := false.B
+      r.module.io.mailboxSideband.resp.bits := 0.U.asTypeOf(new MailboxSbResp)
+      r.module.io.phyToVendor.foreach(_ := 0.U.asTypeOf(new PhyToVendor))
+      r.module.io.d2dToVendor.foreach(_ := DontCare)
+      dontTouch(r.module.io.regsToAdapter)
+      dontTouch(r.module.io.regsToPhy)
+      dontTouch(r.module.io.regsToLink)
+      dontTouch(r.module.io.mailboxSideband.req)
+      r.module.io.vendorToPhy.foreach(dontTouch(_))
+      r.module.io.linkEventIrq.foreach(dontTouch(_))
+      r.module.io.linkErrorIrq.foreach(dontTouch(_))
+    }
+
+    // External reg block: drive our side so the integrator only needs a single <>.
+    io.regBlockIo.foreach { rb =>
+      rb.linkReset := false.B
+      rb.adapterToRegs := 0.U.asTypeOf(new AdapterToRegs)
+      rb.phyToRegs := 0.U.asTypeOf(new PhyToRegs(validatedParams.regs.numModules))
+      rb.linkToRegs := 0.U.asTypeOf(new LinkToRegs)
+      rb.mailboxSideband.req.ready := true.B
+      rb.mailboxSideband.resp.valid := false.B
+      rb.mailboxSideband.resp.bits := 0.U.asTypeOf(new MailboxSbResp)
+      rb.phyToVendor.foreach(_ := 0.U.asTypeOf(new PhyToVendor))
+      rb.d2dToVendor.foreach(_ := DontCare)
+      dontTouch(rb.regsToAdapter)
+      dontTouch(rb.regsToPhy)
+      dontTouch(rb.regsToLink)
+      dontTouch(rb.mailboxSideband.req)
+      rb.vendorToPhy.foreach(dontTouch(_))
+    }
   }
 }

--- a/scala/src/uciedigital/top/UcieDigitalTopParams.scala
+++ b/scala/src/uciedigital/top/UcieDigitalTopParams.scala
@@ -43,7 +43,7 @@ case class UcieDigitalTopParams(
       rxClockPhaseSupport = 0x0
     ),
     numModules = 1,
-    diplomaticIntRouting = true
+    includeInterruptNode = true
   ),
 ) {
   def validate(): UcieDigitalTopParams = {

--- a/scala/test/src/tilelink/TileLinkSpec.scala
+++ b/scala/test/src/tilelink/TileLinkSpec.scala
@@ -68,7 +68,7 @@ function string basename(string path);
     return path;
 endfunction
 
-`define UCIE_Q1_BASE 64'h4000
+`define UCIE_Q1_BASE 64'h200000
 ${codegen.formatDefines()}
 
 interface tltBus (
@@ -590,9 +590,9 @@ class TileLinkSpec extends AnyFunSpec with ChiselSim {
         enableWaves()
         // Allow reset to propagate to UCIe via reset synchronizers.
         c.clock.step(cycles = 5)
-        c.io.reg.expect(c.clock, "h4000".U, 0.U)
-        c.io.reg.write(c.clock, "h4100".U, "hdeadbeef".U)
-        c.io.reg.expect(c.clock, "h4100".U, "hdeadbeef".U)
+        c.io.reg.expect(c.clock, "h200000".U, 0.U)
+        c.io.reg.write(c.clock, "h200100".U, "hdeadbeef".U)
+        c.io.reg.expect(c.clock, "h200100".U, "hdeadbeef".U)
         println("[TEST] Success")
       }
     }


### PR DESCRIPTION
* Added UCIe Digital into TileLink.scala for integration, kept tl mainband mode to not ruin any current testing and thought it would be a good bypass to have.
* Added val ucie = Value(2.U(2.W)) in MainbandSel object.
* PHY facing signals to/from UCIe digital shares the txTestFifo and rxTestFifo async queues with PhyTest.
* Chip facing signals to/from UCIe digital has it's own TX and RX async fifos because the enq and deq clocks need to be cross between chip frequency and 800MHz domain.
* Added UCIe digital chip facing data path into the credit return mechanism, so credits are counted and returned.


Pending TODOs for PHY and Iris integration:
// TODO: RxIO has no clkp/clkn; use the forwarded-clock patterns until sampled clkP/clkN exist.
// Need them for training and link bringup.

// TODO(for Ella): in testchipip OffchipRouter/CanHaveChipletRouting, expose the port wrappers and
// can make CanHaveUcieDigitalRegAndIntNodes and connect them to buses with that,
// or override a val here and connect them to buses in CanHaveChipletRouting instead.
//   ucie_reg_node -> cbus  (node := TLWidthWidget(cbus.beatBytes) := TLBuffer() := _)
//   ucie_int_node -> ibus  (ibus.fromAsync := _)   [after flipping diplomaticIntRouting to true]