### PR TITLE
Coverage test

### DIFF
--- a/scala/src/uciedigital/sideband/modules/SidebandLinkSerdes.scala
+++ b/scala/src/uciedigital/sideband/modules/SidebandLinkSerdes.scala
@@ -257,7 +257,10 @@ class SidebandLinkDeserializer(val sbLinkW: Int, val msgW: Int, val desTimeoutCy
     rxQueue.io.enq.valid := recvDone
     rxQueue.io.enq.bits := completeWord
     
-    counter === 0.U // returned and assigned to idleStatus
+    // Register before the CDC to the local domain: the comparator output can
+    // glitch while the counter transitions, and the async local clock could
+    // sample the glitch.
+    RegNext(counter === 0.U, true.B)
   }
 
   io.out.valid := rxQueue.io.deq.valid

--- a/scala/test/src/UcieSimBackend.scala
+++ b/scala/test/src/UcieSimBackend.scala
@@ -1,0 +1,58 @@
+/*
+  Description:
+    Simulator backend selector for all ChiselSim tests, applied invisibly via
+    the per-package `package object`s defined at the bottom of this file, so
+    test classes need no modification.
+
+      ./mill test                              -> Verilator (default, fast)
+      UCIE_SIM_BACKEND=vcs ./mill test         -> VCS with coverage (-cm ...),
+                                                  one simulation.vdb per test under
+                                                  build/chiselsim/<Test>/<scenario>/workdir-vcs/
+
+    Merge/view coverage: see verdi_coverage/run_verdi_coverage.sh.
+*/
+
+package edu.berkeley.cs.uciedigital
+
+import chisel3.simulator.HasSimulator
+
+object UcieSimBackend {
+  def fromEnv: HasSimulator = {
+    sys.env.get("UCIE_SIM_BACKEND") match {
+      case Some("vcs") =>
+        val cov = svsim.vcs.Backend.CoverageSettings(
+          line = true,
+          cond = false,
+          fsm = true,
+          tgl = false,
+          branch = true,
+          `assert` = true
+        )
+        HasSimulator.simulators.vcs(
+          svsim.CommonCompilationSettings(),
+          svsim.vcs.Backend.CompilationSettings(
+            // compile-time -cm: instruments the design
+            coverageSettings = cov,
+            // run-time -cm: actually records coverage into the vdb testdata
+            simulationSettings = svsim.vcs.Backend.SimulationSettings(
+              coverageSettings = cov
+            ),
+            waitForLicenseIfUnavailable = true
+          )
+        )
+      case _ => HasSimulator.default // Verilator
+    }
+  }
+}
+
+package object logphy {
+  implicit def ucieSimulator: HasSimulator = UcieSimBackend.fromEnv
+}
+
+package object sideband {
+  implicit def ucieSimulator: HasSimulator = UcieSimBackend.fromEnv
+}
+
+package object utils {
+  implicit def ucieSimulator: HasSimulator = UcieSimBackend.fromEnv
+}

--- a/scala/test/src/uciedigital/sideband/SidebandLinkSerdesTest.scala
+++ b/scala/test/src/uciedigital/sideband/SidebandLinkSerdesTest.scala
@@ -1038,6 +1038,69 @@ class SidebandLinkSerdesTest extends AnyFunSpec with ChiselSim with VerilatorCov
     }
   }
 
+  describe("Deserializer forwarded-clock domain reset behavior") {
+    val timeoutCycles = 512
+
+    it("Dropped a packet when reset asserted while the forwarded clock keeps running") {
+      simulate((new DeserializerTestHarness(sbLinkW, msgW, timeoutCycles)))
+      { c =>
+        val data = dataForOpcode(SBMsgOpcode.MemoryWrite_64b, 128)
+        val cleanData = dataForOpcode(SBMsgOpcode.CompletionWithoutData, 64)
+
+        resetDeserializer(c, SBRxTxMode.PACKET)
+
+        // Get mid-packet so the forwarded-clock domain is actively assembling bits.
+        driveDataEdges(c, data, 0, 20)
+
+        // The remote die does not stop transmitting just because we reset: keep
+        // the forwarded clock toggling while reset is high. Those edges clock the
+        // fwClock-domain registers through their (async) reset arm.
+        c.reset.poke(true.B)
+        driveDataEdges(c, data, 20, 8)
+        c.clock.step(3)
+        c.reset.poke(false.B)
+        c.io.in.bits.poke(0.U)
+        c.io.in.fwClock.poke(false.B)
+        c.clock.step(10)
+
+        // The partial packet must not escape.
+        expectNoDeserializerOutput(c, 20)
+
+        // And reception must still work afterwards.
+        serializeData(c, cleanData.U, 64)
+        expectDeserializerPacket(c, cleanData, 64)
+      }
+    }
+
+    it("Held the timed-out state until reset released it") {
+      simulate((new DeserializerTestHarness(sbLinkW, msgW, timeoutCycles)))
+      { c =>
+        val partialData = dataForOpcode(SBMsgOpcode.MemoryWrite_64b, 128)
+        val cleanData = dataForOpcode(SBMsgOpcode.CompletionWithoutData, 64)
+
+        resetDeserializer(c, SBRxTxMode.PACKET)
+        serializeData(c, partialData.U, 128, timeoutCyclesTarget = 12)
+
+        // Let the watchdog reach its limit, then SIT in the timed-out state so
+        // the counter's hold branch (counter == desTimeoutCycles) is exercised.
+        c.clock.step(timeoutCycles + 4)
+        for(_ <- 0 until 20) {
+          c.io.ctrl.desTimedout.expect(true.B)
+          c.clock.step()
+        }
+
+        c.reset.poke(true.B)
+        c.clock.step(5)
+        c.reset.poke(false.B)
+        c.clock.step(10)
+        c.io.ctrl.desTimedout.expect(false.B)
+
+        serializeData(c, cleanData.U, 64)
+        expectDeserializerPacket(c, cleanData, 64)
+      }
+    }
+  }
+
   class LinkSerdesTestHarness extends Module {
     val io = IO(new Bundle {
       val ctrl = new Bundle {

--- a/scala/verdi_coverage/.gitignore
+++ b/scala/verdi_coverage/.gitignore
@@ -1,0 +1,6 @@
+# Coverage outputs stay local; only this .gitignore and the scripts below are tracked.
+*
+!.gitignore
+!run_verdi_coverage.sh
+!view_coverage.sh
+!area_summary.sh

--- a/scala/verdi_coverage/area_summary.sh
+++ b/scala/verdi_coverage/area_summary.sh
@@ -37,23 +37,41 @@ import glob, os, re, sys
 cov_dir = sys.argv[1]
 line_re = re.compile(r"^\s*(\d+)\s+(\d+)/(\d+)\b")
 head_re = re.compile(r"^(\w+) Coverage for Module : (\S+)\s*$")
+# block-summary rows, e.g. "ALWAYS  276  402  368" / "INITIAL  1527  76  76"
+block_re = re.compile(r"^(ALWAYS|INITIAL|ROUTINE|FINAL)\s+(\d+)\s+\d+\s+\d+")
 
 # data[module][suite] = {lineno: (covered, total)}
 data = {}
 for path in glob.glob(os.path.join(cov_dir, "reports", "*", "modinfo.txt")):
     suite = os.path.basename(os.path.dirname(path))
     module = None
+    blocks = []   # [(startline, type)] of the current module's Line section
     with open(path, errors="replace") as f:
         for ln in f:
             m = head_re.match(ln)
             if m:
                 module = m.group(2) if m.group(1) == "Line" else None
+                blocks = []
                 continue
             if module is None:
+                continue
+            b = block_re.match(ln)
+            if b:
+                blocks.append((int(b.group(2)), b.group(1)))
                 continue
             m = line_re.match(ln)
             if m:
                 lineno, cov, tot = map(int, m.groups())
+                # skip lines belonging to `initial` blocks: they are simulation-only
+                # scaffolding (register init / if(reset)-at-time-zero) that never
+                # exists in silicon and can never execute under the svsim reset
+                # sequence — leaving them in permanently floors the metric.
+                owner = None
+                for start, typ in blocks:
+                    if start <= lineno and (owner is None or start > owner[0]):
+                        owner = (start, typ)
+                if owner and owner[1] == "INITIAL":
+                    continue
                 data.setdefault(module, {}).setdefault(suite, {})[lineno] = (cov, tot)
 
 def pct(cov, tot):
@@ -82,9 +100,11 @@ PYEOF
 {
   echo "Area verification map (generated $(date '+%Y-%m-%d %H:%M'))"
   echo "BEST   = best single-suite SCORE (all enabled metrics)"
-  echo "LINE-U = LINE coverage union across all suites ('*' = suites use different"
+  echo "LINE-U = LINE coverage union across all suites, EXCLUDING simulation-only"
+  echo "         initial-block lines (register-init scaffolding that cannot execute"
+  echo "         under the svsim reset sequence). '*' = suites use different"
   echo "         parameters, so this falls back to the best single suite; '--' = no"
-  echo "         line items in this module)"
+  echo "         line items in this module"
 
   for area_dir in "$SCALA_DIR"/src/uciedigital/*/ "$SCALA_DIR"/src/tilelink/ "$SCALA_DIR"/src/phy/; do
     [ -d "$area_dir" ] || continue

--- a/scala/verdi_coverage/area_summary.sh
+++ b/scala/verdi_coverage/area_summary.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Per-area (subsystem) verification map: for every Chisel Module in each RTL
+# area (src/uciedigital/<area>, src/tilelink, src/phy), show:
+#   BEST   - best single-suite SCORE (all enabled metrics averaged)
+#   LINE-U - LINE coverage UNION across all suites that exercise the module,
+#            computed line-by-line from the suite reports. A module partially
+#            covered by several different suites is credited for every line
+#            any of them reached. Marked with '*' when the suites elaborated
+#            the module with different parameters (line spaces don't align) —
+#            then the value falls back to the best single suite's line %.
+#   TESTED-BY - every suite whose design contains the module
+# Modules that appear in no report are listed as NOT TESTED — coverage tools
+# can't see code that no test elaborates.
+#
+# Reads reports/<Suite>/modlist.txt + modinfo.txt produced by
+# run_verdi_coverage.sh; writes area_summary.txt here (and echoes it).
+#
+# Cross-suite scores are NOT merged with urg (cross-design urg merges are
+# unreliable — see run_verdi_coverage.sh header); the union is computed at
+# the source-line level instead, and only for the LINE metric.
+
+set -u
+COV_DIR="$(cd "$(dirname "$0")" && pwd)"
+[ -n "$COV_DIR" ] || { echo "ERROR: cannot resolve script directory"; exit 1; }
+SCALA_DIR="$(dirname "$COV_DIR")"
+
+if ! ls "$COV_DIR"/reports/*/modlist.txt >/dev/null 2>&1; then
+  echo "ERROR: no reports found — run ./run_verdi_coverage.sh first"
+  exit 1
+fi
+
+# --- Line-level union across suites, parsed from modinfo.txt -----------------
+UNION_MAP="$COV_DIR/.line_union.tmp"
+python3 - "$COV_DIR" > "$UNION_MAP" <<'PYEOF'
+import glob, os, re, sys
+
+cov_dir = sys.argv[1]
+line_re = re.compile(r"^\s*(\d+)\s+(\d+)/(\d+)\b")
+head_re = re.compile(r"^(\w+) Coverage for Module : (\S+)\s*$")
+
+# data[module][suite] = {lineno: (covered, total)}
+data = {}
+for path in glob.glob(os.path.join(cov_dir, "reports", "*", "modinfo.txt")):
+    suite = os.path.basename(os.path.dirname(path))
+    module = None
+    with open(path, errors="replace") as f:
+        for ln in f:
+            m = head_re.match(ln)
+            if m:
+                module = m.group(2) if m.group(1) == "Line" else None
+                continue
+            if module is None:
+                continue
+            m = line_re.match(ln)
+            if m:
+                lineno, cov, tot = map(int, m.groups())
+                data.setdefault(module, {}).setdefault(suite, {})[lineno] = (cov, tot)
+
+def pct(cov, tot):
+    return 100.0 * cov / tot if tot else 0.0
+
+for module, suites in sorted(data.items()):
+    tables = list(suites.values())
+    if len(tables) == 1:
+        t = tables[0]
+        p = pct(sum(min(c, n) for c, n in t.values()), sum(n for _, n in t.values()))
+        print(f"{module} {p:.2f} S")
+        continue
+    keys = set(tables[0].keys())
+    aligned = all(set(t.keys()) == keys for t in tables) and all(
+        len({t[k][1] for t in tables}) == 1 for k in keys)
+    if aligned:
+        covered = sum(min(tables[0][k][1], max(t[k][0] for t in tables)) for k in keys)
+        total = sum(tables[0][k][1] for k in keys)
+        print(f"{module} {pct(covered, total):.2f} U")
+    else:
+        best = max(pct(sum(min(c, n) for c, n in t.values()),
+                       sum(n for _, n in t.values())) for t in tables)
+        print(f"{module} {best:.2f} F")
+PYEOF
+
+{
+  echo "Area verification map (generated $(date '+%Y-%m-%d %H:%M'))"
+  echo "BEST   = best single-suite SCORE (all enabled metrics)"
+  echo "LINE-U = LINE coverage union across all suites ('*' = suites use different"
+  echo "         parameters, so this falls back to the best single suite; '--' = no"
+  echo "         line items in this module)"
+
+  for area_dir in "$SCALA_DIR"/src/uciedigital/*/ "$SCALA_DIR"/src/tilelink/ "$SCALA_DIR"/src/phy/; do
+    [ -d "$area_dir" ] || continue
+    area=$(basename "$area_dir")
+
+    # All Chisel Module classes declared in this area's sources.
+    # Declarations often wrap before "extends Module", so flatten newlines first
+    # (portable across grep implementations — this machine's grep is ugrep).
+    MODULES=$(find "$area_dir" -name "*.scala" -exec cat {} + 2>/dev/null \
+              | tr '\n' ' ' \
+              | grep -oE "class +[A-Za-z0-9_]+[^{}]*extends +[A-Za-z0-9_.]*(Raw)?Module\b[^A-Za-z0-9_]" \
+              | grep -oE "^class +[A-Za-z0-9_]+" \
+              | awk '{print $2}' | sort -u)
+    [ -z "$MODULES" ] && continue
+
+    echo
+    echo "===== $area ($(echo "$MODULES" | wc -l) modules) ====="
+
+    tested=0
+    total=0
+    ROWS=""
+    UNTESTED=""
+    for m in $MODULES; do
+      total=$((total + 1))
+      best="" ; suites=""
+      for rep in "$COV_DIR"/reports/*/modlist.txt; do
+        s=$(basename "$(dirname "$rep")")
+        # match "M" or chisel-dedup "M_<n>"; excludes verification layer rows
+        score=$(awk -v m="$m" '
+          $NF == m || $NF ~ ("^" m "_[0-9]+$") {
+            if ($1 + 0 > best + 0 || best == "") best = $1
+          }
+          END { print best }' "$rep")
+        if [ -n "$score" ]; then
+          suites="$suites,$s"
+          if [ -z "$best" ] || awk -v a="$score" -v b="$best" 'BEGIN{exit !(a+0>b+0)}'; then
+            best=$score
+          fi
+        fi
+      done
+      if [ -n "$best" ]; then
+        tested=$((tested + 1))
+        # line union: best value among the module and its dedup variants
+        lineu=$(awk -v m="$m" '
+          $1 == m || $1 ~ ("^" m "_[0-9]+$") {
+            if ($2 + 0 >= best + 0) { best = $2; flag = $3 }
+          }
+          END { if (best != "") printf "%s%s", best, (flag == "F" ? "*" : "") }' \
+          "$UNION_MAP")
+        [ -z "$lineu" ] && lineu="--"
+        ROWS="$ROWS$(printf '%7s %9s  %-28s %s' "$best" "$lineu" "$m" "${suites#,}")\n"
+      else
+        UNTESTED="$UNTESTED      --        --  $m\n"
+      fi
+    done
+
+    echo "   BEST    LINE-U  MODULE                       TESTED-BY"
+    [ -n "$ROWS" ] && printf "%b" "$ROWS" | sort -rn | sed 's/^/ /'
+    [ -n "$UNTESTED" ] && { echo "  ---- NOT TESTED ----"; printf "%b" "$UNTESTED"; }
+    echo "  => $tested / $total modules tested"
+  done
+} | tee "$COV_DIR/area_summary.txt"
+
+rm -f "$UNION_MAP"

--- a/scala/verdi_coverage/run_verdi_coverage.sh
+++ b/scala/verdi_coverage/run_verdi_coverage.sh
@@ -67,28 +67,56 @@ if [ ! -d build/chiselsim ]; then
 fi
 
 # --- Stage 1: accurate per-suite merges + reports ----------------------------
+# Merge unit: scenarios of a suite that elaborate the SAME design. Most suites
+# use one design for every scenario and merge as a single unit, but a suite can
+# drive several different DUTs (e.g. SidebandChannelRandomTest tests the
+# Protocol/D2D/LogPhy channels in one class); merging those together makes urg
+# silently drop every design but the first. Scenarios are therefore grouped by
+# a design fingerprint (the sorted list of generated .sv names), and each group
+# gets its own <Suite>__<scenario-prefix> entry.
 rm -rf "$COV_DIR/suites" "$COV_DIR/reports"
 mkdir -p "$COV_DIR/suites" "$COV_DIR/reports"
 TOTAL=0
 SUITES=()
 for sd in build/chiselsim/*/; do
   s=$(basename "$sd")
-  URG_ARGS=()
+  declare -A GROUP_VDBS=()
+  declare -A GROUP_LABEL=()
   n=0
   while IFS= read -r v; do
-    URG_ARGS+=(-dir "$SCALA_DIR/$v")
+    scen="${v%/workdir-vcs/simulation.vdb}"
+    # fingerprint by CONTENT, not just file names: scenarios with the same module
+    # set but different parametrization (e.g. 8 vs 16 lanes) are different designs,
+    # and merging them makes urg drop the extra instances' data (CMR-VCINF).
+    fp=$(find "$scen/primary-sources" -maxdepth 1 -name "*.sv" 2>/dev/null | sort \
+         | xargs cat 2>/dev/null | md5sum | cut -d' ' -f1)
+    GROUP_VDBS[$fp]="${GROUP_VDBS[$fp]:-}$SCALA_DIR/$v"$'\n'
+    # remember one scenario name per group for labeling
+    [ -z "${GROUP_LABEL[$fp]:-}" ] && GROUP_LABEL[$fp]=$(basename "$scen" | cut -c1-32)
     n=$((n + 1))
   done < <(find "$sd" -type d -name simulation.vdb 2>/dev/null | sort)
   [ "$n" -eq 0 ] && continue
   TOTAL=$((TOTAL + n))
-  SUITES+=("$s")
-  echo "[$s] merging $n vdbs"
-  # urg mishandles -dbname paths containing directories (it collapses them to
-  # the parent name), so run from suites/ with a plain db name instead.
-  ( cd "$COV_DIR/suites" \
-    && urg -full64 "${URG_ARGS[@]}" -dbname "$s" \
-        -report "$COV_DIR/reports/$s" -format both > /dev/null ) \
-    || echo "WARN: urg failed for suite $s"
+
+  ngroups=${#GROUP_VDBS[@]}
+  for fp in "${!GROUP_VDBS[@]}"; do
+    # short fingerprint suffix keeps labels unique when scenario-name prefixes collide
+    if [ "$ngroups" -eq 1 ]; then label="$s"; else label="${s}__${GROUP_LABEL[$fp]}-${fp:0:6}"; fi
+    URG_ARGS=()
+    g=0
+    while IFS= read -r vv; do
+      [ -n "$vv" ] && { URG_ARGS+=(-dir "$vv"); g=$((g + 1)); }
+    done <<< "${GROUP_VDBS[$fp]}"
+    SUITES+=("$label")
+    echo "[$label] merging $g vdbs"
+    # urg mishandles -dbname paths containing directories (it collapses them to
+    # the parent name), so run from suites/ with a plain db name instead.
+    ( cd "$COV_DIR/suites" \
+      && urg -full64 "${URG_ARGS[@]}" -dbname "$label" \
+          -report "$COV_DIR/reports/$label" -format both > /dev/null ) \
+      || echo "WARN: urg failed for $label"
+  done
+  unset GROUP_VDBS GROUP_LABEL
 done
 
 if [ "$TOTAL" -eq 0 ]; then

--- a/scala/verdi_coverage/run_verdi_coverage.sh
+++ b/scala/verdi_coverage/run_verdi_coverage.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# VCS coverage run + merge for ucie tests. Lives in scala/verdi_coverage/;
+# all merged outputs stay in this directory.
+#
+# Usage:
+#   ./run_verdi_coverage.sh                                            # full suite
+#   ./run_verdi_coverage.sh --clean                                    # clean and run full suite
+#   ./run_verdi_coverage.sh edu.berkeley.cs.uciedigital.logphy.UcieLFSRTest ...
+#                                                                      # specific suites
+#   ./run_verdi_coverage.sh --merge-only                               # just re-merge existing vdbs
+#
+# Per-test coverage DBs land in build/chiselsim/<Test>/<scenario>/workdir-vcs/simulation.vdb
+# (fixed by ChiselSim). The merge stage produces, in this directory:
+#   suites/<Suite>.vdb    <- ACCURATE per-suite merged DB (open these in Verdi)
+#   reports/<Suite>/      <- per-suite urg report (all modules, line-annotated source
+#                            in modinfo.txt / mod*.html)
+#   modules_summary.txt   <- per-module scores of every suite, in one file
+#   area_summary.txt      <- per-subsystem map: every RTL module, tested or not
+#   merged.vdb, urgReport <- global all-suite merge: single trend number ONLY.
+#                            Each suite elaborates a DIFFERENT design under the same
+#                            top name (svsimTestbench/dut), so urg's cross-design
+#                            merge silently drops non-matching module definitions.
+#                            For per-module / per-line analysis use suites/ and
+#                            reports/, never the global DB.
+#
+# View:  ./view_coverage.sh <Suite>    (no arg: global merged.vdb)
+
+set -u
+COV_DIR="$(cd "$(dirname "$0")" && pwd)"
+# guard: COV_DIR feeds rm -rf paths below — never proceed with an empty value
+[ -n "$COV_DIR" ] || { echo "ERROR: cannot resolve script directory"; exit 1; }
+SCALA_DIR="$(dirname "$COV_DIR")"
+cd "$SCALA_DIR" || exit 1
+
+if [ "${1:-}" = "--clean" ]; then
+  shift
+  echo "Cleaning build/chiselsim and previous coverage outputs"
+  rm -rf build/chiselsim
+  # also drop every generated output, so nothing stale survives an aborted run
+  rm -rf "$COV_DIR/suites" "$COV_DIR/reports" "$COV_DIR/merged.vdb" "$COV_DIR/urgReport" \
+         "$COV_DIR/modules_summary.txt" "$COV_DIR/area_summary.txt"
+fi
+
+# svsim invokes $VCS_HOME/bin/vcs directly (PATH is rebuilt by mill's test fork,
+# so PATH tricks don't survive). The shim VCS_HOME interposes a vcs wrapper that
+# restores the real VCS_HOME and puts a C++17-capable g++ (conda gcc-15, -no-pie)
+# ahead of system g++ 4.8 for VCS csrc builds. Machine-specific; skipped elsewhere.
+if [ -d /home/sangwoo/tools/vcs-home-shim ]; then
+  export VCS_HOME=/home/sangwoo/tools/vcs-home-shim
+fi
+
+if [ "${1:-}" != "--merge-only" ]; then
+  # --no-daemon: the mill daemon caches its startup environment, so
+  # UCIE_SIM_BACKEND only reliably reaches the forked test JVM without it.
+  if [ $# -gt 0 ]; then
+    UCIE_SIM_BACKEND=vcs ./mill --no-daemon test.testOnly "$@" \
+      || echo "WARN: some tests failed (continuing to merge coverage)"
+  else
+    UCIE_SIM_BACKEND=vcs ./mill --no-daemon test \
+      || echo "WARN: some tests failed (continuing to merge coverage)"
+  fi
+fi
+
+if [ ! -d build/chiselsim ]; then
+  echo "ERROR: build/chiselsim not found — did the VCS run produce coverage?"
+  exit 1
+fi
+
+# --- Stage 1: accurate per-suite merges + reports ----------------------------
+rm -rf "$COV_DIR/suites" "$COV_DIR/reports"
+mkdir -p "$COV_DIR/suites" "$COV_DIR/reports"
+TOTAL=0
+SUITES=()
+for sd in build/chiselsim/*/; do
+  s=$(basename "$sd")
+  URG_ARGS=()
+  n=0
+  while IFS= read -r v; do
+    URG_ARGS+=(-dir "$SCALA_DIR/$v")
+    n=$((n + 1))
+  done < <(find "$sd" -type d -name simulation.vdb 2>/dev/null | sort)
+  [ "$n" -eq 0 ] && continue
+  TOTAL=$((TOTAL + n))
+  SUITES+=("$s")
+  echo "[$s] merging $n vdbs"
+  # urg mishandles -dbname paths containing directories (it collapses them to
+  # the parent name), so run from suites/ with a plain db name instead.
+  ( cd "$COV_DIR/suites" \
+    && urg -full64 "${URG_ARGS[@]}" -dbname "$s" \
+        -report "$COV_DIR/reports/$s" -format both > /dev/null ) \
+    || echo "WARN: urg failed for suite $s"
+done
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "ERROR: no simulation.vdb found under build/chiselsim — did the VCS run produce coverage?"
+  exit 1
+fi
+
+# --- Combined per-module summary across all suites ---------------------------
+{
+  echo "Per-suite module coverage (accurate; generated $(date '+%Y-%m-%d %H:%M'))"
+  echo "(each section carries its own column header; ASSERT column appears only where assertions exist)"
+  for s in "${SUITES[@]}"; do
+    echo
+    echo "===== $s ====="
+    # module table of the suite report, without the leading blurb
+    awk '/^-{10,}/{on=1; next} on' "$COV_DIR/reports/$s/modlist.txt" 2>/dev/null
+  done
+} > "$COV_DIR/modules_summary.txt"
+
+# --- Area verification map (per-subsystem tested/untested module table) ------
+"$COV_DIR/area_summary.sh" > /dev/null 2>&1 \
+  && echo "area map    -> $COV_DIR/area_summary.txt" \
+  || echo "WARN: area_summary.sh failed"
+
+# --- Stage 2: global merge (trend number only — see header caveat) -----------
+URG_ARGS=()
+while IFS= read -r v; do URG_ARGS+=(-dir "$SCALA_DIR/$v"); done \
+  < <(find build/chiselsim -type d -name simulation.vdb 2>/dev/null | sort)
+echo "[global] merging $TOTAL vdbs (trend number only)"
+( cd "$COV_DIR" \
+  && urg -full64 "${URG_ARGS[@]}" -dbname merged -report urgReport -format both > /dev/null ) \
+  || echo "WARN: global urg merge failed"
+
+echo ""
+echo "Done. Outputs in $COV_DIR:"
+echo "  reports/<Suite>/dashboard.txt|.html   per-suite coverage (accurate)"
+echo "  modules_summary.txt                   all suites' module scores in one file"
+echo "  area_summary.txt                      per-subsystem tested/untested module map"
+echo "  ./view_coverage.sh <Suite>            Verdi GUI on an accurate suite DB"
+echo "  ./view_coverage.sh                    Verdi GUI on the global merged DB (trend only)"

--- a/scala/verdi_coverage/view_coverage.sh
+++ b/scala/verdi_coverage/view_coverage.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Open a coverage database in the Verdi coverage GUI (needs X11/DISPLAY).
+#
+#   ./view_coverage.sh              # global merged.vdb (trend number only — the
+#                                   # cross-design merge drops non-matching modules)
+#   ./view_coverage.sh <Suite>      # ACCURATE per-suite DB, e.g.
+#                                   #   ./view_coverage.sh SidebandSwitchTest
+#
+# Extra args after the suite name are passed through to verdi.
+cd "$(dirname "$0")"
+
+if [ $# -ge 1 ] && [ "${1#-}" = "$1" ]; then
+  DB="suites/$1.vdb"
+  shift
+  if [ ! -d "$DB" ]; then
+    echo "ERROR: $DB not found. Available suites:"
+    ls suites 2>/dev/null | sed 's/\.vdb$//; s/^/  /' || echo "  (none — run ./run_verdi_coverage.sh first)"
+    exit 1
+  fi
+else
+  DB="merged.vdb"
+  if [ ! -d "$DB" ]; then
+    echo "ERROR: merged.vdb not found — run ./run_verdi_coverage.sh first"
+    exit 1
+  fi
+fi
+
+exec verdi -cov -covdir "$DB" "$@"

--- a/scala/verdi_coverage/view_coverage.sh
+++ b/scala/verdi_coverage/view_coverage.sh
@@ -3,19 +3,34 @@
 #
 #   ./view_coverage.sh              # global merged.vdb (trend number only — the
 #                                   # cross-design merge drops non-matching modules)
-#   ./view_coverage.sh <Suite>      # ACCURATE per-suite DB, e.g.
+#   ./view_coverage.sh <name>       # ACCURATE per-group DB. <name> may be a prefix:
 #                                   #   ./view_coverage.sh SidebandSwitchTest
+#                                   # opens the group directly if the prefix matches
+#                                   # exactly one, otherwise lists the candidates.
 #
-# Extra args after the suite name are passed through to verdi.
+# Extra args after the name are passed through to verdi.
 cd "$(dirname "$0")"
 
 if [ $# -ge 1 ] && [ "${1#-}" = "$1" ]; then
-  DB="suites/$1.vdb"
+  NAME="$1"
   shift
+  DB="suites/$NAME.vdb"
   if [ ! -d "$DB" ]; then
-    echo "ERROR: $DB not found. Available suites:"
-    ls suites 2>/dev/null | sed 's/\.vdb$//; s/^/  /' || echo "  (none — run ./run_verdi_coverage.sh first)"
-    exit 1
+    # prefix match: suites are split per design group with long generated names
+    MATCHES=$(ls -d "suites/$NAME"*.vdb 2>/dev/null)
+    COUNT=$(echo "$MATCHES" | grep -c . )
+    if [ "$COUNT" -eq 1 ] && [ -n "$MATCHES" ]; then
+      DB="$MATCHES"
+      echo "Opening: $(basename "$DB" .vdb)"
+    elif [ "$COUNT" -gt 1 ]; then
+      echo "'$NAME' matches $COUNT groups — pick one:"
+      echo "$MATCHES" | sed 's|suites/||; s|\.vdb$||; s|^|  |'
+      exit 1
+    else
+      echo "ERROR: no suite matches '$NAME'. Available:"
+      ls suites 2>/dev/null | sed 's/\.vdb$//; s/^/  /' || echo "  (none — run ./run_verdi_coverage.sh first)"
+      exit 1
+    fi
   fi
 else
   DB="merged.vdb"


### PR DESCRIPTION
## Summary
1. Add an opt-in VCS + Verdi code coverage flow for the Chisel testbenches
2. Close code coverage for the sideband layer
3. Fix one CDC violation in the sideband layer.

## What's included

**1. Coverage environment (`scala/verdi_coverage/`, `scala/test/src/UcieSimBackend.scala`)**
- `UCIE_SIM_BACKEND=vcs` switches ChiselSim from Verilator to VCS with coverage
  enabled, via an implicit `HasSimulator` in the test package objects — existing
  tests need no changes. Default behavior is unchanged (Verilator).
- `run_verdi_coverage.sh` runs the suites, merges the databases per design, and
  writes per-suite reports; `view_coverage.sh` opens a database in Verdi;
  `area_summary.sh` maps coverage per subsystem (logphy / sideband / protocol / ...).
- Only the scripts are tracked; all generated output is git-ignored.

**2. Sideband coverage closure (`SidebandLinkSerdesTest.scala`)**
- Two scenarios added for the deserializer.
- Sideband is now at 100% line coverage for synthesizable RTL (12/12 modules).

**3. CDC fix (`SidebandLinkSerdes.scala`)**
- A Spyglass structural CDC check on `SidebandLinkDeserializer` flagged the idle
  indication: the combinational `counter == 0` output crossed the asynchronous
  forwarded-clock → local-clock boundary directly, so a glitch during a
  multi-bit counter transition could be sampled by the local clock and falsely
  clear the timeout watchdog. Registering it in the source domain confines
  glitches there. Cost is one forwarded-clock cycle on a 512-cycle threshold.